### PR TITLE
#166 tidy: update `IMachine` API to use `std::expected`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ CMakeFiles/
 CMakeUserPresets.json
 MachineTestDeps.py
 Machine.aps
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 * Compiler Id and version are now incorporated
   into the package name.
 * Changed top level namespace from MachEmu to meen.
-* IMachine::Run now returns a std::error_code
+* IMachine::Run now returns a std::error_code.
 * IMachine::WaitForCompletion now returns a std::expected.
+* Updated the minimum msvc version required in the README to 1706.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Compiler Id and version are now incorporated
   into the package name.
 * Changed top level namespace from MachEmu to meen.
+* IMachine::Run now returns a std::error_code
+* IMachine::WaitForCompletion now returns a std::expected.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 
 project(${meen} VERSION ${major}.${minor}.${bugfix} LANGUAGES C CXX ASM)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(CMAKE_CXX_STANDARD 23)
 
 if(${enable_rp2040} STREQUAL ON)
   add_executable(Pioasm IMPORTED)
@@ -386,8 +387,6 @@ if(NOT BUILD_TESTING STREQUAL OFF)
   endif()
 
 ##### MEEN TEST
-
-  #set(meen_test meen_test)
 
   if(${build_os} STREQUAL "baremetal")
     set(${meen}_test_source_files tests/${source_dir}/${meen}_test/MeenUnityTest.cpp)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following table displays the current defacto test suites that these unit tes
 
 ### Compilation
 
-Meen uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support,[cppcheck](http://cppcheck.net/) for static analysis and [Doxygen](https://www.doxygen.nl/index.html) for documentation. Supported compilers are GCC (minimum version 12), MSVC(minimum version 16). Clang (minimum version 16) hasn't been tested for a while, therefore, it is no longer officially supported.
+Meen uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support,[cppcheck](http://cppcheck.net/) for static analysis and [Doxygen](https://www.doxygen.nl/index.html) for documentation. Supported compilers are GCC (minimum version 12) and MSVC (minimum version 1706). Clang (minimum version 16) hasn't been tested for a while, therefore, it is no longer officially supported.
 
 #### Pre-requisites
 

--- a/include/meen/IMachine.h
+++ b/include/meen/IMachine.h
@@ -23,10 +23,12 @@ SOFTWARE.
 #ifndef IMACHINE_H
 #define IMACHINE_H
 
+#include <expected>
 #include <functional>
 #include <memory>
 #include <string>
 #include <system_error>
+
 #include "meen/IController.h"
 
 namespace meen
@@ -110,31 +112,26 @@ namespace meen
 										which the cpu will start executing the instructions
 										contained in the rom files that were loaded into memory.
 
-			@return						The duration of the run time of the machine as a uint64_t in nanoseconds.
-
-			@throws						std::runtime_error if no memory or io controller has been set on this
-										machine.
+			@return						A std::error_code - todo: document the error codes.
 
 			@remark						When no program counter is specified cpu instruction
 										execution will begin from memory address 0x00.
 
-			@remark						When the run asynchronous configuration option is set to true
-										the return value will always be 0.
-
 			@see SetMemoryController
 		*/
-		virtual uint64_t Run(uint16_t pc = 0x00) = 0;
+		virtual std::error_code Run(uint16_t pc = 0x00) = 0;
 
 		/** Wait for the machine to finish running
 
 			Block the current thread until the machine execution loop has completed.
 
-			@return						The duration of the run time of the machine as a uint64_t in nanoseconds.
+			@return						A std::expected with an expected value of the duration of the
+										run time of the machine as a uint64_t in nanoseconds and an
+										unexpected value as a std::error_code.
 
-			@remark						When the run asynchronous option is set to false (default) or the Run method has not been called
-										this method will return 0 immediatley.
+			@remark						Repeated calls to this method will return the last valid meen run time. 
 		*/
-		virtual uint64_t WaitForCompletion() = 0;
+		virtual std::expected<uint64_t, std::error_code> WaitForCompletion() = 0;
 
 		/** Set a custom memory controller
 

--- a/include/meen/MEEN_Error.h
+++ b/include/meen/MEEN_Error.h
@@ -34,14 +34,18 @@ namespace meen
 	enum errc
 	{
 		no_error,           /**< No error has occurred. */
-		busy,               /**< The engine is currently running. */
-		clock_resolution,   /**< The resolution can' be set, either it is too high/low or the host clock can't be queried. */
+		async,				/**< An asynchronous operation failed to complete. */
+		busy,               /**< MEEN is currently running. */
+		clock_resolution,   /**< The resolution can't be set, either it is too high/low or the host clock can't be queried. */
+		cpu,				/**< The cpu is invalid. */
 		incompatible_ram,   /**< The ram to load is not compatible with this component. */
 		incompatible_rom,   /**< The rom to load is not compatible with this component. */
 		incompatible_uuid,  /**< The uuid to load does not match this component. */
 		invalid_argument,   /**< An argument passed to this method is invalid. */
+		io_controller,		/**< The supplied io controller is invalid. */
 		json_config,        /**< A JSON configuration parameter is invalid. */
 		json_parse,	        /**< The JSON configuration file/string is malformed. */
+		memory_controller,	/**< The supplied memory controller is invalid. */
 		no_zlib,            /**< MEEN compiled without ZLIB support */
 		not_implemented,    /**< The method is not implemented. */
 		unknown_option      /**< An unknown JSON option was encountered and ignored. */

--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -72,13 +72,13 @@ namespace meen
 
 			@see IMachine::Run
 		*/
-		uint64_t Run(uint16_t pc) final;
+		std::error_code Run(uint16_t pc) final;
 
 		/** WaitForCompletion
 
 			@see IMachine::WaitForCompletion
 		*/
-		uint64_t WaitForCompletion() final;
+		std::expected<uint64_t, std::error_code> WaitForCompletion() final;
 
 		/** SetMemoryController
 

--- a/include/meen/machine_py/MachineHolder.h
+++ b/include/meen/machine_py/MachineHolder.h
@@ -18,7 +18,7 @@ namespace meen
 
         errc OnLoad(std::function<std::string()>&& onLoad);
         errc OnSave(std::function<void(std::string&&)>&& onSave);
-        uint64_t Run(uint16_t offset);
+        errc Run(uint16_t offset);
         std::string Save() const;
         errc SetClockResolution(int64_t clockResolution);
         errc SetIoController(meen::IController* controller);

--- a/source/MEEN_Error.cpp
+++ b/source/MEEN_Error.cpp
@@ -46,6 +46,8 @@ namespace meen
 						return "The engine is running";
 					case errc::clock_resolution:
 						return "The clock resolution can't be set, either it's too high/low or the host clock can't be queried";
+					case errc::cpu:
+						return "The cpu is invalid";
 					case errc::incompatible_ram:
 						return "The ram to load is incompatible with this component";
 					case errc::incompatible_rom:
@@ -54,10 +56,14 @@ namespace meen
 						return "The uuid to load does not match this component";
 					case errc::invalid_argument:
 						return "An argument supplied to the method is invalid";
+					case errc::io_controller:
+						return "Invalid io controller";
 					case errc::json_config:
 						return "A JSON configuration parameter is invalid";
 					case errc::json_parse:
 						return "A JSON parse error occurred while processing the configuration file/string";
+					case errc::memory_controller:
+						return "Invalid memory controller";
 					case errc::no_zlib:
 						return "MEEN compiled without zlib support";
 					case errc::not_implemented:

--- a/source/machine_py/MachineHolder.cpp
+++ b/source/machine_py/MachineHolder.cpp
@@ -50,9 +50,10 @@ namespace meen
 		return machine_->Save();
 	}
 
-	uint64_t MachineHolder::Run(uint16_t offset)
+	errc MachineHolder::Run(uint16_t offset)
 	{
-		return machine_->Run(offset);
+		auto err = machine_->Run(offset);
+		return static_cast<errc>(err.value());
 	}
 
 	errc MachineHolder::SetIoController(meen::IController* controller)
@@ -79,6 +80,6 @@ namespace meen
 		// WaitForCompletion is a long running function that does not interract with Python.
 		// Release the Python Global Interpreter Lock so the calling script doesn't stall.
 		pybind11::gil_scoped_release nogil{};
-		return machine_->WaitForCompletion();
+		return machine_->WaitForCompletion().value_or(0);
 	}
 } // namespace meen

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -38,12 +38,6 @@ SOFTWARE.
 
 namespace meen::tests
 {
-// Use std::expected monadics if they are supported
-#if ((defined __GNUC__ && __GNUC__ >= 13) || (defined _MSC_VER && _MSC_VER >= 1706))
-	static constexpr bool useMonadics_ = true;
-#else
-	static constexpr bool useMonadics_ = true;
-#endif
     static std::shared_ptr<IController> cpmIoController;
     static std::shared_ptr<MemoryController> memoryController;
     static std::shared_ptr<IController> testIoController;
@@ -86,26 +80,21 @@ namespace meen::tests
         err = machine->Run(0x04);
         TEST_ASSERT_FALSE(err);
 
-		if constexpr (useMonadics_ == true)
+// Use std::expected monadics if they are supported
+#if ((defined __GNUC__ && __GNUC__ >= 13) || (defined _MSC_VER && _MSC_VER >= 1706))
+        nanos += machine->WaitForCompletion().or_else([](std::error_code ec)
         {
-            // Use std::expected monadics
-            nanos += machine->WaitForCompletion().or_else([](std::error_code ec)
-            {
-                // We want to force a failure here, ec should be non zero
-                TEST_ASSERT_FALSE(ec);
-                // The machine didn't run, return an expected value of 0
-                return std::expected<uint64_t, std::error_code>(0);
-            }).value();
-        }
-        else
-        {
-            // std::expected monadics are unsupported
-			auto ex = machine->WaitForCompletion();
-			TEST_ASSERT_TRUE(ex);
+            // We want to force a failure here, ec should be non zero
+            TEST_ASSERT_FALSE(ec);
+            // The machine didn't run, return an expected value of 0
+            return std::expected<uint64_t, std::error_code>(0);
+        }).value();
+#else
+        auto ex = machine->WaitForCompletion();
+        TEST_ASSERT_TRUE(ex);
 
-			nanos += ex.value();
-        }
-        
+        nanos += ex.value();
+#endif
         auto error = nanos - 1000000000;
         // Allow an average 500 micros of over sleep error
         TEST_ASSERT_TRUE(error >= 0 && error <= 500000);


### PR DESCRIPTION
- IMachine::WaitForCompletion now return std::expected<uint64_t, error_code> where uint64_t is the time taken in nanos and the error_code is a std::error_code.
- IMachine::Run now return a std::error_code. The total runtime can now only be obtained via a call to WaitForCompletion.
- Updated the minimum msvc version required due to the use of std::expected.
- Added additional error codes.
- Updated the unit tests to account for the new api changes as well as using std::expected monadics where supported.