### PR TITLE
#174 tidy: separate errc enum and meen error_codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * IMachine::Run now returns a std::error_code.
 * IMachine::WaitForCompletion now returns a std::expected.
 * Updated the minimum msvc version required in the README to 1706.
+* Added Error.h with errc enum to compare meen error_code values.
+* Clang is no longer officially supported.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,11 +434,11 @@ if(NOT BUILD_TESTING STREQUAL OFF)
 
     add_custom_command(
         TARGET ${meen}_test POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/MachineTestDeps${build_type}.py ${CMAKE_CURRENT_SOURCE_DIR}/tests/source/${meen_test}/MachineTestDeps.py
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/MachineTestDeps${build_type}.py ${CMAKE_CURRENT_SOURCE_DIR}/tests/source/${meen}_test/MachineTestDeps.py
         )
 
-    install(FILES ${CMAKE_SOURCE_DIR}/tests/source/meen_test/MachineTestDeps.py DESTINATION tests)
-    install(FILES ${CMAKE_SOURCE_DIR}/tests/source/meen_test/test_Machine.py DESTINATION tests)
+    install(FILES ${CMAKE_SOURCE_DIR}/tests/source/${meen}_test/MachineTestDeps.py DESTINATION tests)
+    install(FILES ${CMAKE_SOURCE_DIR}/tests/source/${meen}_test/test_Machine.py DESTINATION tests)
   endif()
 
   if(DEFINED MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ endif()
 
 set(${meen}_public_include_files
   ${include_dir}/meen/Base.h
+  ${include_dir}/meen/Error.h
   ${include_dir}/meen/IController.h
   ${include_dir}/meen/IMachine.h
   ${include_dir}/meen/MachineFactory.h
@@ -150,21 +151,28 @@ set(clock_include_files
 )
 
 set(cpu_include_files
-  ${include_dir}/meen/MEEN_Error.h
   ${include_dir}/meen/cpu/8080.h
   ${include_dir}/meen/cpu/CpuFactory.h
   ${include_dir}/meen/cpu/ICpu.h
 )
 
 set(machine_include_files ${include_dir}/meen/machine/Machine.h)
+
 if(${enable_python_module} STREQUAL ON)
   set(${meen}_py_include_files
     ${include_dir}/meen/machine_py/ControllerPy.h
     ${include_dir}/meen/machine_py/MachineHolder.h
   )
 endif()
-set(opt_include_files ${include_dir}/meen/opt/Opt.h)
-set(utils_include_files ${include_dir}/meen/utils/Utils.h)
+
+set(opt_include_files
+  ${include_dir}/meen/opt/Opt.h
+)
+
+set(utils_include_files
+  ${include_dir}/meen/utils/ErrorCode.h
+  ${include_dir}/meen/utils/Utils.h
+)
 
 set(${meen}_private_include_files
   ${clock_include_files}
@@ -204,11 +212,16 @@ if(${enable_python_module} STREQUAL ON)
   )
 endif()
 
-set(opt_source_files ${source_dir}/opt/Opt.cpp)
-set(utils_source_files ${source_dir}/utils/Utils.cpp)
+set(opt_source_files
+  ${source_dir}/opt/Opt.cpp
+)
+
+set(utils_source_files
+  ${source_dir}/utils/ErrorCode.cpp
+  ${source_dir}/utils/Utils.cpp
+)
 
 set(${meen}_source_files
-  ${source_dir}/MEEN_Error.cpp
   ${clock_source_files}
   ${cpu_source_files}
   ${machine_source_files}

--- a/include/meen/Error.h
+++ b/include/meen/Error.h
@@ -20,8 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#ifndef MEEN_MEEN_ERROR_H
-#define MEEN_MEEN_ERROR_H
+#ifndef MEEN_ERROR_H
+#define MEEN_ERROR_H
 
 #include <system_error>
 
@@ -29,7 +29,8 @@ namespace meen
 {
 	/** Meen Error codes
 
-		Used to define error values that are compatible with std::error_code.
+		Used to define error values that are compatible with std::error_code. These values
+		can be used to compare against any error_code value that a MEEN API method returns.
 	*/
 	enum errc
 	{
@@ -46,34 +47,10 @@ namespace meen
 		json_config,        /**< A JSON configuration parameter is invalid. */
 		json_parse,	        /**< The JSON configuration file/string is malformed. */
 		memory_controller,	/**< The supplied memory controller is invalid. */
-		no_zlib,            /**< MEEN compiled without ZLIB support */
+		no_zlib,            /**< MEEN compiled without ZLIB support. */
 		not_implemented,    /**< The method is not implemented. */
 		unknown_option      /**< An unknown JSON option was encountered and ignored. */
 	};
-
-	/** The custom meen error category
-
-		Defines the name of the error category and the messages that each meen::errc returns.
-	*/
-	const std::error_category& category();
-
-	/** std::error_code wrapper
-
-		A simple convenience wrapper
-
-		@param	ec	The meen::errc to use to create a meen std::error_code
-	*/
-	inline std::error_code make_error_code(errc ec) { return {ec, meen::category()}; }
 } // namespace meen
 
-namespace std
-{
-	/** Boilerplate
-
-		Inform std that our meen::errc enum is a std::error_code enum.
-	*/
-	template<>
-	struct is_error_code_enum<meen::errc> : public std::true_type {};
-} // namespace std
-
-#endif // MEEN_MEEN_ERROR_H
+#endif // MEEN_ERROR_H

--- a/include/meen/clock/CpuClock.h
+++ b/include/meen/clock/CpuClock.h
@@ -31,8 +31,8 @@ SOFTWARE.
 #include <pico/stdlib.h>
 #endif // ENABLE_MEEN_RP2040
 
-#include "meen/MEEN_Error.h"
 #include "meen/clock/ICpuClock.h"
+#include "meen/utils/ErrorCode.h"
 
 namespace meen
 {

--- a/include/meen/machine_py/MachineHolder.h
+++ b/include/meen/machine_py/MachineHolder.h
@@ -1,8 +1,8 @@
 #ifndef MACHINEHOLDER_H
 #define MACHINEHOLDER_H
 
+#include "meen/Error.h"
 #include "meen/MachineFactory.h"
-#include "meen/MEEN_Error.h"
 
 namespace meen
 {

--- a/include/meen/utils/ErrorCode.h
+++ b/include/meen/utils/ErrorCode.h
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef MEEN_ERRORCODE_H
+#define MEEN_ERRORCODE_H
+
+#include <system_error>
+
+#include "meen/Error.h"
+
+namespace meen
+{
+	/** The custom meen error category
+
+		Defines the name of the error category and the messages that each meen::errc returns.
+	*/
+	const std::error_category& category();
+
+	/** std::error_code wrapper
+
+		A simple convenience wrapper
+
+		@param	ec	The meen::errc to use to create a meen std::error_code
+	*/
+	inline std::error_code make_error_code(errc ec) { return {ec, meen::category()}; }
+} // namespace meen
+
+namespace std
+{
+	/** Boilerplate
+
+		Inform std that our meen::errc enum is a std::error_code enum.
+	*/
+	template<>
+	struct is_error_code_enum<meen::errc> : public std::true_type {};
+} // namespace std
+
+#endif // MEEN_ERRORCODE_H

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -29,8 +29,8 @@ SOFTWARE.
 #endif // ENABLE_NLOHMANN_JSON
 #include "meen/utils/Utils.h"
 #endif // ENABLE_MEEN_SAVE
-#include "meen/MEEN_Error.h"
 #include "meen/cpu/8080.h"
+#include "meen/utils/ErrorCode.h"
 
 namespace meen
 {

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -34,10 +34,10 @@ SOFTWARE.
 #endif // ENABLE_NLOHMANN_JSON
 #include "meen/utils/Utils.h"
 #endif // ENABLE_MEEN_SAVE
-#include "meen/MEEN_Error.h"
 #include "meen/clock/CpuClockFactory.h"
 #include "meen/cpu/CpuFactory.h"
 #include "meen/machine/Machine.h"
+#include "meen/utils/ErrorCode.h"
 
 using namespace std::chrono;
 

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -23,8 +23,8 @@ SOFTWARE.
 #include <assert.h>
 #include <fstream>
 
-#include "meen/MEEN_Error.h"
 #include "meen/opt/Opt.h"
+#include "meen/utils/ErrorCode.h"
 
 namespace meen
 {

--- a/source/utils/ErrorCode.cpp
+++ b/source/utils/ErrorCode.cpp
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "meen/MEEN_Error.h"
+#include "meen/utils/ErrorCode.h"
 
 namespace meen
 {

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -101,17 +101,11 @@ class MachineTest(unittest.TestCase):
         err = self.machine.SetOptions(r'{"clockResolution":16666667,"isrFreq":0.5}')
         self.assertEqual(err, ErrorCode.NoError)
 
-        nanos = 0
-        iterations = 1
+        err = self.machine.Run(0x0004)
+        self.assertEqual(err, ErrorCode.NoError)
+        nanos = self.machine.WaitForCompletion()
 
-        for i in range(iterations):
-            if runAsync == True:
-                self.machine.Run(0x0004)
-                nanos += self.machine.WaitForCompletion()
-            else:
-                nanos += self.machine.Run(0x0004)
-
-        error = nanos / iterations - 1000000000
+        error = nanos - 1000000000
         self.assertTrue(error >= 0 and error <= 500000)
 
     def test_RunTimed(self):


### PR DESCRIPTION
- The errc enum is resides in meen/Error.h and can be used to compare the meen::error_code value to.
- The meen error_codes now reside in utils/ErrorCode (renamed from MEEN_ErrorCode).
- Updated the unit tests (and other applicable code) to the errc enum rather than magic numbers.
- Fixed a bug where the python unit test auto generated dependencies file was being copied to the wrong directory causing the python unit tests to error (not run).