### PR TITLE
#177 tidy: mem controller Load return type

### DIFF
--- a/tests/include/test_controllers/MemoryController.h
+++ b/tests/include/test_controllers/MemoryController.h
@@ -24,6 +24,7 @@ SOFTWARE.
 #define MEMORYCONTROLLER_H
 
 #include <array>
+#include <system_error>
 #include <vector>
 
 #include "meen/IController.h"
@@ -70,11 +71,14 @@ namespace meen
 
 			@param	offset					The memory location to load the program into.
 
-			@throw	std::runtime_error		The rom file failed to open.
-			@throw	std::length_error		The rom file is too large for the given offset.
-			@throw	std::invalid_argument	Failed to read the rom file into memory.
+			@return 						A std::error_code:<br>
+			
+											std::errc::no_such_file_or_directory: the rom file at the path specified does not exist.<br>
+											std::errc::file_too_large: the rom file is larger than the available memory.<br>
+											std::errc::no_buffer_space: the rom file can not be loaded at the offset specified.<br>
+											std::errc::io_error: a read error occurred while loading the rom.
 		*/
-		int Load(const char* romFilePath, uint16_t offset);
+		std::error_code Load(const char* romFilePath, uint16_t offset);
 		
 		/** Memory clear
 		

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -80,16 +80,22 @@ namespace meen::Tests
 	void MachineTest::SetUp()
 	{
 		memoryController_->Clear();
+		
 		//CP/M Warm Boot is at memory address 0x00, this will be
 		//emulated with the exitTest subroutine.
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "/exitTest.bin").c_str(), 0x00));
+		auto err = memoryController_->Load((programsDir_ + "/exitTest.bin").c_str(), 0x00);
+		ASSERT_FALSE(err);
+		
 		//CP/M BDOS print message system call is at memory address 0x05,
 		//this will be emulated with the bdosMsg subroutine.
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "/bdosMsg.bin").c_str(), 0x05));
+		err = memoryController_->Load((programsDir_ + "/bdosMsg.bin").c_str(), 0x05);
+		ASSERT_FALSE(err);
+
 		machine_->SetMemoryController(memoryController_);
 		machine_->SetIoController(testIoController_);
+		
 		// Set default options
-		auto err = machine_->SetOptions(nullptr);
+		err = machine_->SetOptions(nullptr);
 		EXPECT_FALSE(err);
 	}
 
@@ -120,9 +126,10 @@ namespace meen::Tests
 		});
 
 		auto dir = programsDir_ + name;
-		ASSERT_EQ(0, memoryController_->Load(dir.c_str(), 0x100));
+		auto err = memoryController_->Load(dir.c_str(), 0x100);
+		ASSERT_FALSE(err);
 
-		auto err = machine_->Run(0x100);
+		err = machine_->Run(0x100);
 		EXPECT_FALSE(err);
 	}
 
@@ -164,8 +171,11 @@ namespace meen::Tests
 		auto err = machine_->SetOptions(R"({"clockResolution":25000000,"runAsync":true, "isrFreq":0.25})"); // must be async so the Run method returns immediately
 		EXPECT_FALSE(err);
 
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "nopStart.bin").c_str(), 0x04));
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "nopEnd.bin").c_str(), 0xC353));
+		err = memoryController_->Load((programsDir_ + "nopStart.bin").c_str(), 0x04);
+		ASSERT_FALSE(err);
+		
+		err = memoryController_->Load((programsDir_ + "nopEnd.bin").c_str(), 0xC353);
+		ASSERT_FALSE(err);
 
 		EXPECT_NO_THROW
 		(
@@ -220,8 +230,11 @@ namespace meen::Tests
 		// going under so the cpu sleeps at the end
 		// of the program so it maintains sync. It's never going to
 		// be perfect, but its close enough for testing purposes).
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "nopStart.bin").c_str(), 0x04));
-		ASSERT_EQ(0, memoryController_->Load((programsDir_ + "nopEnd.bin").c_str(), 0xC353));
+		err = memoryController_->Load((programsDir_ + "nopStart.bin").c_str(), 0x04);
+		ASSERT_FALSE(err);
+
+		err = memoryController_->Load((programsDir_ + "nopEnd.bin").c_str(), 0xC353);
+		ASSERT_FALSE(err);
 
 		// 25 millisecond resolution, service interrupts every 8.25 milliseconds
 		err = machine_->SetOptions(R"({"clockResolution":25000000,"isrFreq":0.25})");
@@ -295,7 +308,9 @@ namespace meen::Tests
 			memoryController_->Write(0x00FE, 0xD3);
 			// The data to write to the controller that will trigger the ISR::Load interrupt
 			memoryController_->Write(0x00FF, 0xFD);
-			ASSERT_EQ(0, memoryController_->Load((programsDir_ + "/TST8080.COM").c_str(), 0x100));
+
+			err = memoryController_->Load((programsDir_ + "/TST8080.COM").c_str(), 0x100);
+			ASSERT_FALSE(err);
 			// Set the rom/ram offsets for tst8080, note that tst8080 uses 256 bytes of stack space
 			// located at the end of the program so this will make up the ram size since the program
 			// never writes beyond this.

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -61,8 +61,11 @@ namespace meen::tests
         // going under so the cpu sleeps at the end
         // of the program so it maintains sync. It's never going to
         // be perfect, but its close enough for testing purposes).
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load((programsDir + "nopStart.bin").c_str(), 0x04));
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load((programsDir + "nopEnd.bin").c_str(), 0xC353));
+        err = memoryController->Load((programsDir + "nopStart.bin").c_str(), 0x04);
+        TEST_ASSERT_FALSE(err);
+        
+        err = memoryController->Load((programsDir + "nopEnd.bin").c_str(), 0xC353);
+        TEST_ASSERT_FALSE(err);
 
         // 25 millisecond resolution, service interrupts every 8.25 milliseconds
         err = machine->SetOptions(R"({"clockResolution":25000000, "isrFreq":0.25})");
@@ -133,7 +136,9 @@ namespace meen::tests
         memoryController->Write(0x00FE, 0xD3);
         // The data to write to the controller that will trigger the ISR::Load interrupt
         memoryController->Write(0x00FF, 0xFD);
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load((programsDir + "/TST8080.COM").c_str(), 0x100));
+
+        err = memoryController->Load((programsDir + "/TST8080.COM").c_str(), 0x100);
+        TEST_ASSERT_FALSE(err);
         // Set the rom/ram offsets for tst8080, note that tst8080 uses 256 bytes of stack space
         // located at the end of the program so this will make up the ram size since the program
         // never writes beyond this.
@@ -222,9 +227,11 @@ namespace meen::tests
         });
 
         auto dir = programsDir + name;
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load(dir.c_str(), 0x100));
 
-        auto err = machine->Run(0x100);
+        auto err = memoryController->Load(dir.c_str(), 0x100);
+        TEST_ASSERT_FALSE(err);
+
+        err = machine->Run(0x100);
         TEST_ASSERT_FALSE(err);
     }
 
@@ -278,8 +285,11 @@ namespace meen::tests
         auto err = machine->SetOptions(R"({"clockResolution":25000000,"runAsync":true,"isrFreq":0.25})"); // must be async so the Run method returns immediately
         TEST_ASSERT_FALSE(err);
 
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load((programsDir + "nopStart.bin").c_str(), 0x04));
-        TEST_ASSERT_EQUAL_UINT8(0, memoryController->Load((programsDir + "nopEnd.bin").c_str(), 0xC353));
+        err = memoryController->Load((programsDir + "nopStart.bin").c_str(), 0x04);
+        TEST_ASSERT_FALSE(err);
+
+        err = memoryController->Load((programsDir + "nopEnd.bin").c_str(), 0xC353);
+        TEST_ASSERT_FALSE(err);
 
         // We aren't interested in saving, clear the onSave callback
         err = machine->OnSave(nullptr);
@@ -392,14 +402,19 @@ void setUp()
     meen::tests::memoryController->Clear();
     //CP/M Warm Boot is at memory address 0x00, this will be
     //emulated with the exitTest subroutine.
-    TEST_ASSERT_EQUAL_INT8(0, meen::tests::memoryController->Load((meen::tests::programsDir + "/exitTest.bin").c_str(), 0x00));
+    auto err = meen::tests::memoryController->Load((meen::tests::programsDir + "/exitTest.bin").c_str(), 0x00);
+    TEST_ASSERT_FALSE(err);
+
     //CP/M BDOS print message system call is at memory address 0x05,
     //this will be emulated with the bdosMsg subroutine.
-    TEST_ASSERT_EQUAL_INT8(0, meen::tests::memoryController->Load((meen::tests::programsDir + "/bdosMsg.bin").c_str(), 0x05));
+    err = meen::tests::memoryController->Load((meen::tests::programsDir + "/bdosMsg.bin").c_str(), 0x05);
+    TEST_ASSERT_FALSE(err);
+    
     meen::tests::machine->SetMemoryController(meen::tests::memoryController);
     meen::tests::machine->SetIoController(meen::tests::testIoController);
+    
     // Set default options
-    auto err = meen::tests::machine->SetOptions(nullptr);
+    err = meen::tests::machine->SetOptions(nullptr);
     TEST_ASSERT_FALSE(err);
 }
 

--- a/tests/source/test_controllers/MemoryController.cpp
+++ b/tests/source/test_controllers/MemoryController.cpp
@@ -37,35 +37,35 @@ namespace meen
 		return memorySize_;
 	}
 
-	int MemoryController::Load(const char* romFile, uint16_t offset)
+	std::error_code MemoryController::Load(const char* romFile, uint16_t offset)
 	{
 		std::ifstream fin(romFile, std::ios::binary | std::ios::ate);
 
 		if (!fin)
 		{
-			return -1;
+			return std::make_error_code(std::errc::no_such_file_or_directory);
 		}
 
 		if (static_cast<size_t>(fin.tellg()) > memorySize_)
 		{
-			return -1;
+			return std::make_error_code(std::errc::file_too_large);
 		}
 
 		uint16_t size = static_cast<uint16_t>(fin.tellg());
 
 		if (size > memorySize_ - offset)
 		{
-			return -1;
+			return std::make_error_code(std::errc::no_buffer_space);
 		}
 
 		fin.seekg(0, std::ios::beg);
 
 		if (!(fin.read(reinterpret_cast<char*>(&memory_[offset]), size)))
 		{
-			return -1;
+			return std::make_error_code(std::errc::io_error);
 		}
 
-		return 0;
+		return std::error_code{};
 	}
 
 	std::array<uint8_t, 16> MemoryController::Uuid() const

--- a/tests/source/test_controllers/RP2040MemoryController.cpp
+++ b/tests/source/test_controllers/RP2040MemoryController.cpp
@@ -58,19 +58,24 @@ namespace meen
 		return memorySize_;
 	}
 
-	int MemoryController::Load(const char* romFile, uint16_t offset)
+	std::error_code MemoryController::Load(const char* romFile, uint16_t offset)
 	{
 		auto sv = std::string_view(romFile, strlen(romFile));
 
 		auto copyFromFlashToRam = [this, offset](uint8_t* src, uint16_t srcSize)
 		{
+			if (srcSize > memory_.size())
+			{
+				return std::make_error_code(std::errc::file_too_large);
+			}
+		
 			if(srcSize > memory_.size() - offset)
 			{
-				return -1;
+				return std::make_error_code(std::errc::no_buffer_space);
 			}
 
 			memcpy(memory_.data() + offset, src, srcSize);
-			return 0;
+			return std::error_code{};
 		};
 
 		if(sv.ends_with("bdosMsg.bin") == true)
@@ -107,7 +112,7 @@ namespace meen
 		}
 		else
 		{
-			return -1;
+			return std::error_code{};
 		}
 	}
 


### PR DESCRIPTION
- Change the return type of the Memory Controller Load method from int to std::error_code.
- Update the unit tests to reflect the new Load return type.