### PR TITLE
#180 tidy: update OnLoad/Save api methods

### DIFF
--- a/include/meen/IMachine.h
+++ b/include/meen/IMachine.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #include <string>
 #include <system_error>
 
+#include "meen/Error.h" 
 #include "meen/IController.h"
 
 namespace meen
@@ -249,12 +250,14 @@ namespace meen
 										will be ignored.
 			@since	version 1.5.0
 		*/
-		virtual std::error_code OnSave(std::function<void(const char* json)>&& onSave) = 0;
+		virtual std::error_code OnSave(std::function<errc(const char* json)>&& onSave) = 0;
 
 		/** Machine load state initiation handler
 		
 			Registers a method that will be called when the ISR::Load interrupt is triggered. The register
-			method returns a const char* which is the json machine state to load.
+			method returns a std:error_code and accepts two parameters: json - the char array to write the
+			machine state json, jsonLen - the length of the json state array. When the json array is nullptr
+			the length of the json state array must be written to jsonLen.
 
 			@param	onLoad				The method to call to get the json machine state to load when the ISR::Load
 										interrupt is triggered. Is mutually exclusive with the OnSave completion handler.
@@ -267,6 +270,9 @@ namespace meen
 
 			@remark						The function parameter onLoad will be called from a different thread from which this
 										method was called if the runAsync or loadAsync config options have been specified.
+
+			@remark						The function parameter onLoad should return errc::invalid argument if it's jsonLen
+										parameter is nullptr or if it's jsonLen parameter is too small.
 
 			@remark						The machine state can fail to load for numerous reasons:
 										- when the machine cpu does not match the load state cpu.
@@ -284,7 +290,7 @@ namespace meen
 
 			@since	version 1.5.0
 		*/
-		virtual std::error_code OnLoad(std::function<const char*()>&& onLoad) = 0;
+		virtual std::error_code OnLoad(std::function<errc(char* json, int* jsonLen)>&& onLoad) = 0;
 
 		/** Destruct the machine
 

--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -65,8 +65,8 @@ namespace meen
 		//cppcheck-suppress unusedStructMember
 		bool running_{};
 #ifdef ENABLE_MEEN_SAVE
-		std::function<const char*()> onLoad_{};
-		std::function<void(const char* json)> onSave_{};
+		std::function<std::error_code(char* json, int* jsonLen)> onLoad_{};
+		std::function<std::error_code(const char* json)> onSave_{};
 #endif // ENABLE_MEEN_SAVE
 		friend void RunMachine(Machine* machine);
 	public:
@@ -107,13 +107,13 @@ namespace meen
 
 			@see IMachine::OnLoad
 		*/
-		std::error_code OnLoad(std::function<const char*()>&& onLoad) final;
+		std::error_code OnLoad(std::function<errc(char* json, int* jsonLen)>&& onLoad) final;
 
 		/** OnSave
 
 			@see IMachine::OnSave
 		*/
-		std::error_code OnSave(std::function<void(const char* json)>&& onSave) final;
+		std::error_code OnSave(std::function<errc(const char* json)>&& onSave) final;
 	};
 } // namespace meen
 

--- a/include/meen/machine_py/MachineHolder.h
+++ b/include/meen/machine_py/MachineHolder.h
@@ -18,7 +18,7 @@ namespace meen
 
         MachineHolder(Cpu cpu);
         errc OnLoad(std::function<std::string()>&& onLoad);
-        errc OnSave(std::function<void(std::string&&)>&& onSave);
+        errc OnSave(std::function<errc(std::string&&)>&& onSave);
         errc Run(uint16_t offset);
         errc SetIoController(meen::IController* controller);
         errc SetMemoryController(meen::IController* controller);

--- a/tests/source/test_controllers_py/TestControllersPy.cpp
+++ b/tests/source/test_controllers_py/TestControllersPy.cpp
@@ -12,7 +12,10 @@ PYBIND11_MODULE(TestControllersPy, TestControllers)
     py::class_<meen::MemoryController, meen::IController>(TestControllers, "MemoryController")
         .def(py::init<>())
         .def("Clear", &meen::MemoryController::Clear)
-        .def("Load", &meen::MemoryController::Load)
+        .def("Load", [](meen::MemoryController* controller, const char* romFilePath, uint16_t offset)
+        {
+            return controller->Load(romFilePath, offset).value();
+        })
         .def("Read", &meen::MemoryController::Read)
         .def("Write", &meen::MemoryController::Write)
         .def("ServiceInterrupts", &meen::MemoryController::ServiceInterrupts);


### PR DESCRIPTION
- Both `OnLoad` and `OnSave` api methods now return a std::error_code.
- The callback arguments to both `onLoad/Save` are now required to return meen::errc.
- The `OnLoad` callback parameter now accepts two arguments `json` and `jsonLen` for loading the state.
- The `OnLoad` callback parameter for Python differs from the C++ version in that it returns a string and accepts no arguments.
- Updated all code and unit tests to reflect the api changes.