### PR TITLE
#191 tidy: remove the IMachine::Run program counter parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
   `AttachMemoryController` and added `DetachIoController`
   and `DetachMemoryController` to allow for the machine
   to take and relinquish controller ownership.
-  * Added support for the i8080 halt instruction.
+* Added support for the i8080 halt instruction.
+* Removed the pc (program counter) parameter from
+  `IMachine::Run`.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/include/meen/IMachine.h
+++ b/include/meen/IMachine.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -109,27 +109,27 @@ namespace meen
 	{
 		/** Run the machine
 
-			Run the roms loaded into memory initialising execution at the given
-			program counter.
+			Start executing the instructions that reside in the currently loaded
+			memory controller.
 
-			@param	pc					The program counter is the memory address at
-										which the cpu will start executing the instructions
-										contained in the rom files that were loaded into memory.
+			@remark						Before a program has been loaded, current existing memory will continue ti be executed.
+										This is relevant when no inital program has been loaded. In this case, current existing
+										memory will be executed from address 0x0000. The memory controller's internal memory
+										should be initialised to 0x00 before the first call to IMachine::Run is made. Failure
+										to initialise the memory to a known state will result in undefined behaviour.
 
 			@return						A std::error_code:
 
-										errc::memory_controller: no memory controller has been set.
-										errc::io_controller: no io controller has been set.
+										errc::memory_controller: no memory controller has been attached.
+										errc::io_controller: no io controller has been attached.
 										errc::busy: meen is running.
 										errc::cpu: the machine cpu is invalid.
 										errc::clock_resolution: the clock is invalid or the supplied clock resolution is too high.
 
-			@remark						When no program counter is specified cpu instruction
-										execution will begin from memory address 0x00.
-
-			@see meen::errc
+			@sa							OnLoad
+			@sa							meen::errc
 		*/
-		virtual std::error_code Run(uint16_t pc = 0x00) = 0;
+		virtual std::error_code Run() = 0;
 
 		/** Wait for the machine to finish running
 

--- a/include/meen/cpu/8080.h
+++ b/include/meen/cpu/8080.h
@@ -208,7 +208,7 @@ namespace meen
 		std::error_code Load(const std::string&& json, bool checkUuid) final;
 		std::string Save() const final;
 #endif // ENABLE_MEEN_SAVE
-		void Reset(uint16_t programCounter) final;
+		void Reset() final;
 		void SetMemoryController(IController* memoryController) final;
 		void SetIoController(IController* ioController) final;
 		/* End I8080 overrides */

--- a/include/meen/cpu/ICpu.h
+++ b/include/meen/cpu/ICpu.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ namespace meen
 
 		virtual uint8_t Interrupt(ISR isr) = 0;
 
-		virtual void Reset(uint16_t pc) = 0; // pc should not be needed now that load is improved
+		virtual void Reset() = 0;
 
 #ifdef ENABLE_MEEN_SAVE
 		virtual std::error_code Load(const std::string&& json, bool checkUuid) = 0;

--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -79,7 +79,7 @@ namespace meen
 
 			@see IMachine::Run
 		*/
-		std::error_code Run(uint16_t pc) final;
+		std::error_code Run() final;
 
 		/** WaitForCompletion
 

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -728,7 +728,7 @@ void Intel8080::SetIoController(IController* ioController)
 }
 
 //This essentially powers on the cpu
-void Intel8080::Reset(uint16_t pc)
+void Intel8080::Reset()
 {
 	a_.reset();
 	b_.reset();

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -736,7 +736,7 @@ namespace meen
 		m->runTime_ = currTime.count();
 	}
 
-	std::error_code Machine::Run(uint16_t pc)
+	std::error_code Machine::Run()
 	{
 		if (running_ == true)
 		{
@@ -771,7 +771,7 @@ namespace meen
 			return make_error_code(errc::clock_resolution);
 		}
 
-		cpu_->Reset(pc);
+		cpu_->Reset();
 		clock_->Reset();
 		runTime_ = 0;
 		running_ = true;

--- a/source/machine_py/MachineModule.cpp
+++ b/source/machine_py/MachineModule.cpp
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -91,9 +113,9 @@ PYBIND11_MODULE(meenPy, meen)
                 return static_cast<meen::errc>(machine.OnSave(nullptr).value());
             }
         })
-        .def("Run", [](meen::IMachine& machine, uint16_t offset)
+        .def("Run", [](meen::IMachine& machine)
         {
-            return static_cast<meen::errc>(machine.Run(offset).value());
+            return static_cast<meen::errc>(machine.Run().value());
         })
         .def("AttachIoController", [](meen::IMachine& machine, meen::IController* controller)
         {

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -156,7 +156,7 @@ namespace meen::Tests
 		});
 		EXPECT_FALSE(err);
 
-		err = machine_->Run(0x00);
+		err = machine_->Run();
 		EXPECT_FALSE(err);
 		EXPECT_TRUE(saveTriggered);
 	}
@@ -233,7 +233,7 @@ namespace meen::Tests
 			err = machine_->OnSave(nullptr);
 			EXPECT_TRUE(err.value() == errc::no_error || err.value() == errc::not_implemented);
 
-			err = machine_->Run(0x00);
+			err = machine_->Run();
 			EXPECT_FALSE(err);
 
 			// All these methods should return busy
@@ -274,7 +274,7 @@ namespace meen::Tests
 		err = machine_->SetOptions(R"({"clockResolution":25000000,"isrFreq":0.25})");
 		EXPECT_FALSE(err);
 
-		err = machine_->Run(0x00);
+		err = machine_->Run();
 		EXPECT_FALSE(err);
 
 // Use std::expected monadics if they are supported
@@ -379,7 +379,7 @@ namespace meen::Tests
 			err = machine_->AttachIoController(std::move(cpmIoController_));
 			EXPECT_FALSE(err);
 
-			err = machine_->Run(0x0000);
+			err = machine_->Run();
 			EXPECT_FALSE(err);
 
 			auto ex = machine_->WaitForCompletion();
@@ -406,7 +406,7 @@ namespace meen::Tests
 			EXPECT_FALSE(err);
 
 			// run it again, but this time trigger the load interrupt
-			err = machine_->Run(0x0000);
+			err = machine_->Run();
 			EXPECT_FALSE(err);
 
 			ex = machine_->WaitForCompletion();


### PR DESCRIPTION
Like the title says, `IMachine::Run` no longer accepts a program counter parameter, the program counter is now set by the `IMachine::OnLoad` callback. All references to it have now been removed.