### PR TITLE
#190 tidy: remove Opt::Ram and Opt::Rom and all referernces to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   load/save support. 
 * Added support for ArduinoJson for baremetal.
 * Added RP2040 support.
-* Code refactor for a 2x performace boost.
+* Code refactor for a minimum 2x performace boost.
 * The ISR frequency is now honoured when no clock resolution
   is set.
 * Compiler Id and version are now incorporated
@@ -22,7 +22,7 @@
   Save, GetState.
 * Factory methods are based on cpu type (removed MakeMachine
   in favour of Make8080Machine) and take no options.
-* Unit test memory controller Load method returns a std::error_code
+* Removed the Load method from the unit test memory controller.
 * The `IMachine::OnLoad` callback signature has changed.
 * Removed superfluous pybind machine holder.
 * Replaced `IMachine` api methods `SetIoController` and
@@ -33,6 +33,7 @@
 * Added support for the i8080 halt instruction.
 * Removed the pc (program counter) parameter from
   `IMachine::Run`.
+* Removed IMachine::SetOptions support for ram/rom.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/include/meen/IMachine.h
+++ b/include/meen/IMachine.h
@@ -43,44 +43,38 @@ namespace meen
 
 		@code{.cpp}
 
-		// Create a synchronous i8080 machine running as fast as possible 
+		// Create a synchronous i8080 machine running as fast as possible
 		auto machine = Make8080Machine();
 
-		// Create a custom memory controller (See tests for examples)
-		auto customMemoryController = IControllerPtr(new CustomMemoryController());
-
-		// Load the controller with a program via a custom controller method
-		static_cast<CustomMemoryController*>(customMemoryController.get())->LoadProgram("myProgram.com");
-
-		// Create a custom IO Controller and attach it to the machine (See tests for examples)
+		// Create a custom IO Controller and attach it to the machine (See unit tests for examples)
 		machine->AttachIOController(IControllerPtr(new CustomIOController()));
 
-		// Attach the custom memory controller with a loaded program to the machine
-		machine->AttachMemoryController(std::move(customMemoryController));
+		// Create a custom memory controller and attach it to the machine (See unit tests for examples)
+		machine->AttachMemoryController(IControllerPtr(new customMemoryController()));
 
+		// Can be called from a different thread if the runAsync/loadAsync options are specifed
 		machine->OnLoad([](char* json, int* jsonLength)
 		{
-			// Return the json state to load, could be read from disk for example
-  			if(json == nullptr)
-  			{
-    			*jsonLen = JsonToLoadLength;
-  			}
-  			else
- 			{
-    			memcpy(json, jsonToLoad, *jsonLength);
-  			}
+			// The machine state to load in json format: load all bytes from the rom `myProgram.com` from
+			// the current directory into memory at address 0x0000 and start executing the rom from address 256.
+			constexpr auto jsonToLoad = R"({"cpu":{"pc":256},"memory":{"rom:"{"bytes":"file://myProgram.com"}}})"sv;
+			json == nullptr ?  *jsonLen = jsonToLoad.size() : memcpy(json, jsonToLoad.data(), *jsonLength);
+			return errc::no_error;
+
+			// "myProgram.json" save file as written to by the OnSave handler can be read from and written to the
+			// json buffer.
+			// NOTE: this will fail if the save file does not match "myProgram.com".
 		});
 
 		// Can be called from a different thread if the runAsync/saveAsync options are specifed
 		machine->OnSave([](const char* json)
 		{
-			// Handle the machines current state, for example, writing it to disk
-			std::cout << json << std::endl;
-		});		
-		
-		// Set the ram/rom sizes (0x2000 and 0x4000) and offsets (0x0000, 0x2000) for this custom memory controller
-		// These values are used for load and save requests
-		machine_->SetOptions(R"({"romOffset":0,"romSize":8192,"ramOffset":8192,"ramSize":16384})");
+			// Write the save state to disk
+			FILE* fout = fopen("myProgram.json", "w");
+			fwrite(json, 1, strlen(json), fin);
+			fclose(fout);
+			return errc::no_error;
+		});
 
 		// Set the clock resolution - not setting this will run the
 		// machine as fast as possible (default)
@@ -90,8 +84,7 @@ namespace meen
 		// controller ServiceInterrupts override generates an ISR::Quit interrupt
 		auto runTime = machine->Run();
 
-		// Run the machine asychronously - this can be done by setting the following json config
-		// option either in the MakeMachine factory method or via IMachine::SetOptions
+		// Run the machine asychronously - this can be done by setting the following json config option
 		machine->SetOptions(R"({"runAsync":true})");
 		machine->Run();
 

--- a/include/meen/opt/Opt.h
+++ b/include/meen/opt/Opt.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -118,24 +118,6 @@ namespace meen
 				True for asynchronous, false for synchronous.
 			*/
 			bool LoadAsync() const;
-
-			/** Ram metadata
-
-				This vector defines blocks of ram.
-
-				The first pair entry is the offset from the start of memory to the start of the ram block.
-				The second pair entry is the size of the ram block.
-			*/
-			std::vector<std::pair<uint16_t, uint16_t>> Ram() const;
-
-			/** Rom metadata
-
-				This vector defines blocks of rom.
-
-				The first pair entry is the offset from the start of memory to the start of the rom block.
-				The second pair entry is the size of the rom block.
-			*/
-			std::vector<std::pair<uint16_t, uint16_t>> Rom() const;
 
 			/** Machine state save mode
 

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -79,7 +79,7 @@ namespace meen
 #else
 								"none"
 #endif // ENABLE_BASE64
-								R"(","loadAsync":false,"rom":{"file":[{"offset":0,"size":0}]},"ram":{"block":[{"offset":0,"size":0}]},"saveAsync":false)"
+								R"(","loadAsync":false,"saveAsync":false)"
 #endif // ENABLE_MEEN_SAVE
 								R"(,"isrFreq":0,"runAsync":false})";
 		return defaults;
@@ -242,50 +242,6 @@ namespace meen
 #else
 		return json_["loadAsync"].as<bool>();
 #endif // ENABLE_NLOHMANN_JSON
-	}
-
-	std::vector<std::pair<uint16_t, uint16_t>> Opt::Ram() const
-	{
-		std::vector<std::pair<uint16_t, uint16_t>> ram;
-#ifdef ENABLE_NLOHMANN_JSON
-		auto blocks = json_["ram"]["block"];
-
-		for (const auto& block : blocks)
-		{
-			ram.emplace_back(std::pair(block["offset"].get<uint16_t>(), block["size"].get<uint16_t>()));
-		}
-#else
-		auto r = json_["ram"].as<JsonObjectConst>();
-		auto blocks = r["block"].as<JsonArrayConst>();
-
-		for (const auto& block : blocks)
-		{
-			ram.emplace_back(std::pair(block["offset"].as<uint16_t>(), block["size"].as<uint16_t>()));
-		}
-#endif // ENABLE_NLOHMANN_JSON
-		return ram;
-	}
-
-	std::vector<std::pair<uint16_t, uint16_t>> Opt::Rom() const
-	{
-		std::vector<std::pair<uint16_t, uint16_t>> rom;
-#ifdef ENABLE_NLOHMANN_JSON
-		auto files = json_["rom"]["file"];
-
-		for(const auto& file : files)
-		{
-			rom.emplace_back(std::pair(file["offset"].get<uint16_t>(), file["size"].get<uint16_t>()));
-		}
-#else
-		auto r = json_["rom"].as<JsonObjectConst>();
-		auto files = r["file"].as<JsonArrayConst>();
-
-		for(const auto& file : files)
-		{
-			rom.emplace_back(std::pair(file["offset"].as<uint16_t>(), file["size"].as<uint16_t>()));
-		}
-#endif // ENABLE_NLOHMANN_JSON
-		return rom;
 	}
 
 	bool Opt::SaveAsync() const

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -232,11 +232,6 @@ namespace meen::tests
         auto cpm = static_cast<CpmIoController*>(cpmIoController.get());
         // Trigger a save when the 3000th cycle has executed.
         cpm->SaveStateOn(3000);
-        // Set the rom/ram offsets for tst8080, note that tst8080 uses 256 bytes of stack space
-        // located at the end of the program so this will make up the ram size since the program
-        // never writes beyond this.
-        err = machine->SetOptions(R"({"rom":{"file":[{"offset":0,"size":1727}]},"ram":{"block":[{"offset":1727,"size":256}]}})");
-        TEST_ASSERT_FALSE(err);
 
         err = machine->AttachIoController(std::move(cpmIoController));
         TEST_ASSERT_FALSE(err);

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import json
 import MachineTestDeps
 import re
@@ -134,8 +154,6 @@ class MachineTest(unittest.TestCase):
         self.memoryController.Write(0x00FE, 0xD3, None)
         self.memoryController.Write(0x00FF, 0xFD, None)
         err = self.memoryController.Load(self.programsDir + 'TST8080.COM', 0x0100)
-        self.assertEqual(err, ErrorCode.NoError)
-        err = self.machine.SetOptions(r'{"rom":{"file":[{"offset":0,"size":1727}]},"ram":{"block":[{"offset":1727,"size":256}]},"isrFreq":0}') # remove isrFreq
         self.assertEqual(err, ErrorCode.NoError)
         err = self.machine.AttachIoController(self.cpmIoController)
         self.assertEqual(err, ErrorCode.NoError)


### PR DESCRIPTION
The Opt methods of `Rom` and `Ram` have now been removed. Any ram/rom json parameters used in any `IMachine::SetOptions` calls have also been removed.