### PR TITLE
#207 chore: decouple on load from with save

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.build import can_run
@@ -37,8 +57,9 @@ class MeenRecipe(ConanFile):
         "tests/source/*",
 
     def requirements(self):
+        self.requires("base64/0.5.2")
+ 
         if self.options.get_safe("with_save", False):
-            self.requires("base64/0.5.2")
             self.requires("hash-library/8.0")
 
         if(self.settings.os == "baremetal"):
@@ -103,7 +124,7 @@ class MeenRecipe(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["enable_python_module"] = self.options.get_safe("with_python", False)
         tc.cache_variables["enable_zlib"] = self.options.get_safe("with_zlib", False)
-        tc.cache_variables["enable_base64"] = self.options.get_safe("with_save", False)
+        tc.cache_variables["enable_base64"] = True
         tc.cache_variables["enable_hash_library"] = self.options.get_safe("with_save", False)
         tc.cache_variables["enable_rp2040"] = self.options.get_safe("with_rp2040", False)
         tc.variables["build_os"] = self.settings.os

--- a/include/meen/IController.h
+++ b/include/meen/IController.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,9 +67,8 @@ namespace meen
 								load/save is requested the controller must implement this
 								method and a non-empty uuid returned otherwise no load/save
 								operation will be performed and an error will be logged.
-			@remark				This method will be made pure in 2.0.0
 		*/
-		virtual std::array<uint8_t, 16> Uuid() const { return {}; }
+		virtual std::array<uint8_t, 16> Uuid() const = 0;
 
 		/** Read from a device
 		

--- a/include/meen/cpu/8080.h
+++ b/include/meen/cpu/8080.h
@@ -204,8 +204,8 @@ namespace meen
 		/* I8080 overrides */
 		uint8_t Execute() final;
 		uint8_t Interrupt(ISR isr);
-#ifdef ENABLE_MEEN_SAVE
 		std::error_code Load(const std::string&& json, bool checkUuid) final;
+#ifdef ENABLE_MEEN_SAVE
 		std::string Save() const final;
 #endif // ENABLE_MEEN_SAVE
 		void Reset() final;

--- a/include/meen/cpu/ICpu.h
+++ b/include/meen/cpu/ICpu.h
@@ -46,9 +46,9 @@ namespace meen
 
 		virtual void Reset() = 0;
 
-#ifdef ENABLE_MEEN_SAVE
 		virtual std::error_code Load(const std::string&& json, bool checkUuid) = 0;
 
+#ifdef ENABLE_MEEN_SAVE
 		virtual std::string Save() const = 0;
 #endif // ENABLE_MEEN_SAVE
 		virtual ~ICpu() = default;

--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -67,8 +67,8 @@ namespace meen
 		std::map<uint16_t, uint16_t> ramMetadata_;
 		//cppcheck-suppress unusedStructMember
 		bool running_{};
-#ifdef ENABLE_MEEN_SAVE
 		std::function<std::error_code(char* json, int* jsonLen)> onLoad_{};
+#ifdef ENABLE_MEEN_SAVE
 		std::function<std::error_code(const char* json)> onSave_{};
 #endif // ENABLE_MEEN_SAVE
 		friend void RunMachine(Machine* machine);

--- a/include/meen/opt/Opt.h
+++ b/include/meen/opt/Opt.h
@@ -100,7 +100,6 @@ namespace meen
 			*/
 			bool RunAsync() const;
 
-#ifdef ENABLE_MEEN_SAVE
 			/** Compressor
 
 				Supported compressors, currently only zlib is supported.
@@ -119,6 +118,7 @@ namespace meen
 			*/
 			bool LoadAsync() const;
 
+#ifdef ENABLE_MEEN_SAVE
 			/** Machine state save mode
 
 				True for asynchronous, false for synchronous.

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -21,7 +21,6 @@ SOFTWARE.
 */
 
 #include <assert.h>
-#ifdef ENABLE_MEEN_SAVE
 #ifdef ENABLE_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
 #else
@@ -29,7 +28,6 @@ SOFTWARE.
 #include <ArduinoJson.h>
 #endif // ENABLE_NLOHMANN_JSON
 #include "meen/utils/Utils.h"
-#endif // ENABLE_MEEN_SAVE
 #include "meen/cpu/8080.h"
 #include "meen/utils/ErrorCode.h"
 
@@ -298,10 +296,9 @@ Intel8080::Intel8080()
 		[&] { return Cmp(++pc_, "CPI"); },
 		[&] { return Rst(); },
 	});
-#endif
+#endif // ENABLE_OPCODE_TABLE
 }
 
-#ifdef ENABLE_MEEN_SAVE
 std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 {
 #ifdef ENABLE_NLOHMANN_JSON
@@ -412,6 +409,7 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 	return make_error_code(errc::no_error);
 }
 
+#ifdef ENABLE_MEEN_SAVE
 std::string Intel8080::Save() const
 {
 	auto b64 = Utils::BinToTxt("base64", "none", uuid_.data(), uuid_.size());

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -66,7 +66,6 @@ namespace meen
 	constexpr std::string Opt::DefaultOpts()
 	{
 		std::string defaults =	R"({"clockResolution":-1)"
-#ifdef ENABLE_MEEN_SAVE
 								R"(,"compressor":")"
 #ifdef ENABLE_ZLIB
 								"zlib"
@@ -79,7 +78,10 @@ namespace meen
 #else
 								"none"
 #endif // ENABLE_BASE64
+#ifdef ENABLE_MEEN_SAVE
 								R"(","loadAsync":false,"saveAsync":false)"
+#else
+								R"(")"
 #endif // ENABLE_MEEN_SAVE
 								R"(,"isrFreq":0,"runAsync":false})";
 		return defaults;
@@ -167,7 +169,6 @@ namespace meen
 			{
 				return make_error_code(errc::json_config);
 			}
-#ifdef ENABLE_MEEN_SAVE
 #ifndef ENABLE_ZLIB
 #ifdef ENABLE_NLOHMANN_JSON
 			if (json.contains("compressor") == true && json["compressor"].get<std::string_view>() == "zlib")
@@ -178,7 +179,6 @@ namespace meen
 				return make_error_code(errc::no_zlib);
 			}
 #endif // ENABLE_ZLIB
-#endif // ENABLE_MEEN_SAVE
 		}
 
 #ifdef ENABLE_NLOHMANN_JSON
@@ -216,7 +216,6 @@ namespace meen
 #endif // ENABLE_NLOHMANN_JSON
 	}
 
-#ifdef ENABLE_MEEN_SAVE
 	std::string Opt::Compressor() const
 	{
 #ifdef ENABLE_NLOHMANN_JSON
@@ -237,13 +236,18 @@ namespace meen
 
 	bool Opt::LoadAsync() const
 	{
+#ifdef ENABLE_MEEN_SAVE
 #ifdef ENABLE_NLOHMANN_JSON
 		return json_["loadAsync"].get<bool>();
 #else
 		return json_["loadAsync"].as<bool>();
 #endif // ENABLE_NLOHMANN_JSON
+#else
+		return false;
+#endif // ENABLE_MEEN_SAVE
 	}
 
+#ifdef ENABLE_MEEN_SAVE
 	bool Opt::SaveAsync() const
 	{
 #ifdef ENABLE_NLOHMANN_JSON

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -148,7 +148,7 @@ namespace meen::Tests
 			saveTriggered = true;
 			return errc::no_error;
 		});
-		EXPECT_FALSE(err);
+		EXPECT_TRUE(err.value() == errc::no_error || err.value() == errc::not_implemented);
 
 		err = machine_->OnLoad([name, extra, offset](char* json, int* jsonLen)
 		{
@@ -165,7 +165,7 @@ namespace meen::Tests
 
 		err = machine_->Run();
 		EXPECT_FALSE(err);
-		EXPECT_TRUE(saveTriggered);
+		EXPECT_TRUE(saveTriggered || machine_->OnSave(nullptr).value() == errc::not_implemented);
 	}
 
     void MachineTest::RunTestSuite(const char* suiteName, const char* expectedState, const char* expectedMsg, size_t pos)
@@ -253,7 +253,7 @@ namespace meen::Tests
 			err = machine_->OnLoad([](char*, int*){ return errc::no_error; });
 			EXPECT_EQ(errc::busy, err.value());
 			err = machine_->OnSave([](const char*){ return errc::no_error; });
-			EXPECT_EQ(errc::busy, err.value());
+			EXPECT_TRUE(err.value() == errc::busy || err.value() == errc::not_implemented);
 
 			// Since we are running async we need to wait for completion
 			machine_->WaitForCompletion();
@@ -326,7 +326,7 @@ namespace meen::Tests
 				return errc::no_error;
 			});
 
-			if(err.value() == errc::json_config)
+			if(err.value() == errc::not_implemented)
 			{
 				// not implemented, skip the test
 				GTEST_SKIP() << "Machine::OnSave not supported";

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -167,7 +167,7 @@ namespace meen::tests
             return errc::no_error;
         });
 
-        if(err.value() == errc::json_config)
+        if(err.value() == errc::not_implemented)
         {
             // not implemented, skip the test
             TEST_IGNORE_MESSAGE("Machine::OnSave not supported");
@@ -336,7 +336,7 @@ namespace meen::tests
             saveTriggered = true;
             return errc::no_error;
         });
-        TEST_ASSERT_FALSE(err);
+        TEST_ASSERT_TRUE(err.value() == errc::no_error || err.value() == errc::not_implemented);
 
         err = machine->OnLoad([name, extra, offset](char* json, int* jsonLen)
         {
@@ -353,7 +353,7 @@ namespace meen::tests
 
         err = machine->Run();
         TEST_ASSERT_FALSE(err);
-        TEST_ASSERT_TRUE(saveTriggered);
+        TEST_ASSERT_TRUE(saveTriggered || machine->OnSave(nullptr).value() == errc::not_implemented);
     }
 
     static void test_SetNullptrMemoryController()
@@ -408,7 +408,7 @@ namespace meen::tests
         err = machine->OnLoad([](char*, int*){return errc::no_error;});
         TEST_ASSERT_EQUAL_INT(static_cast<int>(errc::busy), err.value());
         err = machine->OnSave([](const char*){ return errc::no_error; });
-        TEST_ASSERT_EQUAL_INT(static_cast<int>(errc::busy), err.value());
+        TEST_ASSERT_TRUE(err.value() == static_cast<int>(errc::busy) || err.value() == static_cast<int>(errc::not_implemented));
 
         // Since we are running async we need to wait for completion
         auto expected = machine->WaitForCompletion();

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -244,7 +244,7 @@ class i8080Test(unittest.TestCase):
         self.assertIn(err, [ErrorCode.NoError, ErrorCode.NotImplemented])
         err = self.machine.Run()
         self.assertEqual(err, ErrorCode.NoError)
-        self.assertTrue(self.saveTriggered)
+        self.assertTrue(self.saveTriggered or self.machine.OnSave(None) == ErrorCode.NotImplemented)
 
         if suiteName == '8080EXM.COM':
             self.assertNotIn(expectedMsg, self.cpmIoController.Message())


### PR DESCRIPTION
- Don't protect the onLoad mechanics with the ENABLE_MEEN_SAVE defne, allowing it to be supported at all times.
- Make IController::UUID pure virtual for 2.0.0 (api breaking change, hence the need to wait for 2.0.0).