### PR TITLE
#189 chore: implement the cpm test io controllers Read method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2.0.0
 * Updated the project layout for improved workflow.
-* Added std::error_code support.
+* Added `std::error_code` support.
 * Removed the use of exceptions (methods return std::error_code).
 * Binary package now built with cpack.
 * Added Conan option `with_save` to enable/disable 
@@ -13,15 +13,15 @@
 * Compiler Id and version are now incorporated
   into the package name.
 * Changed top level namespace from MachEmu to meen.
-* IMachine::Run now returns a std::error_code.
-* IMachine::WaitForCompletion now returns a std::expected.
+* `IMachine::Run` now returns a `std::error_code`.
+* `IMachine::WaitForCompletion` now returns a `std::expected`.
 * Updated the minimum msvc version required in the README to 1706.
 * Added Error.h with errc enum to compare meen error_code values.
 * Clang is no longer officially supported.
-* Removed the following IMachine API methods: SetClockResolution,
-  Save, GetState.
-* Factory methods are based on cpu type (removed MakeMachine
-  in favour of Make8080Machine) and take no options.
+* Removed the following IMachine API methods: `SetClockResolution`,
+  `Save`, `GetState`.
+* Factory methods are based on cpu type (removed `MakeMachine`
+  in favour of `Make8080Machine`) and take no options.
 * Removed the Load method from the unit test memory controller.
 * The `IMachine::OnLoad` callback signature has changed.
 * Removed superfluous pybind machine holder.
@@ -33,11 +33,13 @@
 * Added support for the i8080 halt instruction.
 * Removed the pc (program counter) parameter from
   `IMachine::Run`.
-* Removed IMachine::SetOptions support for ram/rom.
+* Removed `IMachine::SetOptions` support for ram/rom.
 * Tidied up the unit tests by removing the i8080 test
   files and using base64 encoded versions instead.
 * More flexibility for the `IMachine::OnLoad` callback json
   allowing for more methods of loading program roms.
+* Cpm test io controller's `Read` method has been implemented
+  and it's `Message` method removed.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/tests/include/test_controllers/CpmIoController.h
+++ b/tests/include/test_controllers/CpmIoController.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@ SOFTWARE.
 #define CPMIOCONTROLLER_H
 
 #include <array>
+#include <list>
 #include <memory>
-#include <string>
 
 #include "test_controllers/BaseIoController.h"
 
@@ -52,10 +52,10 @@ namespace meen
 		
 		/** Output message buffer
 
-			A character buffer where program output messages are printed to.
+			A list of bytes where program output messages are printed to.
 		*/
 		//cppcheck-suppress unusedStructMember
-		std::string message_;
+		std::list<uint8_t> output_;
 
 		/** Printing mode
 
@@ -80,18 +80,6 @@ namespace meen
 		//cppcheck-suppress unusedStructMember
 		uint8_t addrHi_{};
 	public:
-		/** Output message buffer
-
-			The output message generated from one of the print modes.
-			
-			@return		A copy of the internal message buffer as a std::string.
-
-			@remark		When this method returns the internal message buffer will be cleared.
-
-			@see		CpmIoController::message_
-		*/
-		std::string Message();
-
 		/**	Uuid
 
 			Unique universal identifier for this controller.

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -136,6 +136,18 @@ class MachineTest(unittest.TestCase):
     def test_RunTimedAsync(self):
         self.RunTimed(True)
 
+    def ReadCpmIoControllerBuffer(self):
+        message = ''
+        byte = 0x00; 
+
+        while byte != 0x04: # ascii end of transmission
+            byte = self.cpmIoController.Read(0, None)
+		
+            if byte != 0x04:
+                message += chr(byte)
+
+        return message
+
     def Load(self, runAsync):
         saveStates = []
         self.loadIndex = 0
@@ -186,7 +198,7 @@ class MachineTest(unittest.TestCase):
         time = self.machine.WaitForCompletion()
         self.assertNotEqual(time, 0)
 
-        self.assertIn('CPU IS OPERATIONAL', self.cpmIoController.Message())
+        self.assertIn('CPU IS OPERATIONAL', self.ReadCpmIoControllerBuffer())
 
         self.cpmIoController.Write(0xFD, 0, None)
         self.cpmIoController.SaveStateOn(-1)
@@ -196,7 +208,7 @@ class MachineTest(unittest.TestCase):
         time = self.machine.WaitForCompletion()
         self.assertNotEqual(time, 0)
 
-        self.assertIn('CPU IS OPERATIONAL', self.cpmIoController.Message())
+        self.assertIn('CPU IS OPERATIONAL', self.ReadCpmIoControllerBuffer())
         self.assertTrue(len(saveStates) == 2 or len(saveStates) == 3)
         self.assertEqual(saveStates[0], r'{"cpu":{"uuid":"base64://O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":19,"b":19,"c":0,"d":19,"e":0,"h":19,"l":0,"s":86},"pc":1236,"sp":1981},"memory":{"uuid":"base64://zRjYZ92/TaqtWroc666wMQ==","rom":{"bytes":"base64://md5://BVt1f9Z97W/m34J/iH68cQ=="},"ram":{"size":64042,"bytes":"base64://zlib://eJztzlENgDAQBbDlnQAETBeSpwABCEDAfnHBktEqaGt/ca4OfKrXUVUzT+5cGVn9AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGBXL4n+BO8="}}}')
         self.assertEqual(saveStates[1], r'{"cpu":{"uuid":"base64://O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":170,"b":170,"c":9,"d":170,"e":170,"h":170,"l":170,"s":86},"pc":2,"sp":1981},"memory":{"uuid":"base64://zRjYZ92/TaqtWroc666wMQ==","rom":{"bytes":"base64://md5://BVt1f9Z97W/m34J/iH68cQ=="},"ram":{"size":64042,"bytes":"base64://zlib://eJztzkENgDAQALDBJeOJAGTghAdW8HQSSHAwP3xxwRJoFbSUv2h1Pco19W68ZIk5Iu5xz23IPGvvDwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABf9QDDAAbX"}}}')
@@ -228,6 +240,18 @@ class i8080Test(unittest.TestCase):
         # A base64 encoded code fragment that emulates cp/m bdos function 4 - raw console output.  
         self.bdosMsg = 'base64://9XnTAP4CyhEAetMBe9MC8ck='
 
+    def ReadCpmIoControllerBuffer(self):
+        message = ''
+        byte = 0x00; 
+
+        while byte != 0x04: # ascii end of transmission
+            byte = self.cpmIoController.Read(0, None)
+		
+            if byte != 0x04:
+                message += chr(byte)
+
+        return message
+
     def CheckMachineState(self, expected, actual):
         e = json.loads(expected)
         a = json.loads(actual.rstrip('\0'))
@@ -247,9 +271,9 @@ class i8080Test(unittest.TestCase):
         self.assertTrue(self.saveTriggered or self.machine.OnSave(None) == ErrorCode.NotImplemented)
 
         if suiteName == '8080EXM.COM':
-            self.assertNotIn(expectedMsg, self.cpmIoController.Message())
+            self.assertNotIn(expectedMsg, self.ReadCpmIoControllerBuffer())
         else:
-            self.assertIn(expectedMsg, self.cpmIoController.Message())
+            self.assertIn(expectedMsg, self.ReadCpmIoControllerBuffer())
 
     def test_8080Pre(self):
         self.RunTestSuite('8080PRE.COM', r'{"uuid":"base64://O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":0,"b":0,"c":9,"d":3,"e":50,"h":1,"l":0,"s":86},"pc":5,"sp":1280}', '8080 Preliminary tests complete')

--- a/tests/source/test_controllers/CpmIoController.cpp
+++ b/tests/source/test_controllers/CpmIoController.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,22 +25,23 @@ SOFTWARE.
 
 namespace meen
 {
-	std::string CpmIoController::Message()
-	{
-		auto str = std::move(message_);
-		message_.clear();
-		return str;
-	}
-
 	std::array<uint8_t, 16> CpmIoController::Uuid() const
 	{
 		return{ 0x32, 0x8C, 0xCF, 0x78, 0x76, 0x1B, 0x48, 0xA4, 0x98, 0x2C, 0x1A, 0xAA, 0x5F, 0x14, 0x31, 0x24 };
 	}
 
-	//Not used, just return 0;
 	uint8_t CpmIoController::Read([[maybe_unused]] uint16_t deviceNumber, [[maybe_unused]] IController* controller)
 	{
-		return 0;
+		if (output_.empty() == true)
+		{
+			return 0x04; // ascii end of transmission
+		}
+		else
+		{
+			auto byte = output_.front();
+			output_.pop_front();
+			return byte;
+		}
 	}
 
 	void CpmIoController::Write(uint16_t deviceNumber, uint8_t value, IController* memoryController)
@@ -49,13 +50,11 @@ namespace meen
 		{
 			case 0:
 			{
-				//printf("Print Mode: %d\n", value);
 				printMode_ = value;
 				break;
 			}
 			case 1:
 			{
-				//printf("Addr Hi: %d\n", value);
 				addrHi_ = value;
 				break;
 			}
@@ -70,16 +69,14 @@ namespace meen
 
 						while (aChar != '$')
 						{
-							//printf("%c", aChar);
-							message_.push_back(aChar);
+							output_.push_back(aChar);
 							aChar = memoryController->Read(++addr, nullptr);
 						}
 						break;
 					}
 					case 2:
 					{
-						//printf ("%c", value);
-						message_.push_back(value);
+						output_.push_back(value);
 						break;
 					}
 					default:

--- a/tests/source/test_controllers/CpmIoController.py
+++ b/tests/source/test_controllers/CpmIoController.py
@@ -1,15 +1,38 @@
+# Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from BaseIoController import BaseIoController
 from meenPy import ISR
 
 class CpmIoController(BaseIoController):
     def __init__(self):
         super().__init__()
-        self._message = ''
+        self._output = []
         self._printMode = 0
         self._addrHi = 0
 
     def Read(self, deviceNumber, controller):
-        return 0
+        if len(self._output) > 0:
+            return self._output.pop(0)
+        else:
+            return 0x04 # ascii end of transmission
 
     def Write(self, deviceNumber, value, controller):
         match deviceNumber:
@@ -21,14 +44,14 @@ class CpmIoController(BaseIoController):
                 match self._printMode:
                     case 9:
                         addr = (self._addrHi << 8) | value
-                        aChar = chr(controller.Read(addr, None))
+                        aChar = controller.Read(addr, None)
 
-                        while aChar != '$':
-                            self._message += aChar
+                        while aChar != 0x24: #'$'
+                            self._output.append(aChar)
                             addr += 1
-                            aChar = chr(controller.Read(addr, None))
+                            aChar = controller.Read(addr, None)
                     case 2:
-                        self._message += chr(value)
+                        self._output.append(value)
                     case _:
                         pass
             case _:
@@ -36,9 +59,6 @@ class CpmIoController(BaseIoController):
 
     def ServiceInterrupts(self, currTime, cycles, memoryController):
         return super().ServiceInterrupts(currTime, cycles, memoryController)
-
-    def Message(self):
-        return self._message
 
     def Uuid(self):
         return [0x32, 0x8C, 0xCF, 0x78, 0x76, 0x1B, 0x48, 0xA4, 0x98, 0x2C, 0x1A, 0xAA, 0x5F, 0x14, 0x31, 0x24]

--- a/tests/source/test_controllers_py/TestControllersPy.cpp
+++ b/tests/source/test_controllers_py/TestControllersPy.cpp
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include <pybind11/pybind11.h>
 
 #include "meen/IController.h"
@@ -25,7 +47,6 @@ PYBIND11_MODULE(TestControllersPy, TestControllers)
 
     py::class_<meen::CpmIoController, meen::IController>(TestControllers, "CpmIoController")
         .def(py::init<>())
-        .def("Message", &meen::CpmIoController::Message)
         .def("Read", &meen::CpmIoController::Read)
         .def("Write", &meen::CpmIoController::Write)
         .def("SaveStateOn", &meen::CpmIoController::SaveStateOn)


### PR DESCRIPTION
- Implemented the cpm test io controller's `IoController::Read` method and removed the its Message method.
- Updated all the unit tests to use the cpm io controller Read method.
- 0x04 (ascii end of transmission) is returned from the cpm io controller's Read methods when its internal buffer is empty.