### PR TITLE
#215 feat: add json protocol to IMachine::SetOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,13 @@ runTime = machine->WaitForCompletion();
 
 ### Configuration Options
 
-A number of configuration options are available that can be used to control the behaviour of the machine. The options must be supplied as a string in json format or the location of the json configuration file preceded with a recognised protocol.
+A number of configuration options are available that can be used to control the behaviour of the machine.<br>
+The options must be supplied in json format defined by one of the following protocols:
 
-Supported protocols:
-
-| Protocol | Remarks                                   |
-|:---------|:------------------------------------------|
-| file://  | Load a json file from local disk storage  |
+| Protocol | Remarks                                                               |
+|:---------|:--------------------------------------------------------------------- |
+| file://  | Load json from a file on local disk specified in the remaining string |
+| json://  | Load json from the remaining string                                   |
 
 The following table describes the supported options (note, when no option is specifed the one marked as default will be used):
 
@@ -363,8 +363,8 @@ The following table describes the supported options (note, when no option is spe
 
 Configuration options can be supplied to MEEN via the IMachine::SetOptions api method:
 
-C++ - `machine->SetOptions(R"({"isrFreq":1})")`<br>
-Python - `self.machine.SetOptions(r'{"isrFreq":1.0}')`
+C++ - `machine->SetOptions(R"(json://{"isrFreq":1})")`<br>
+Python - `self.machine.SetOptions(r'file://myConfig.json')`
 
 See `IMachine::SetOptions` for further details.
 

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -141,9 +141,9 @@ namespace meen
 				}
 #endif // ENABLE_NLOHMANN_JSON
 			}
-			else
+			else if (jsonStr.starts_with("json://") == true)
 			{
-				// parse as if raw json
+				jsonStr.remove_prefix(strlen("json://"));
 #ifdef ENABLE_NLOHMANN_JSON
 				json = nlohmann::json::parse(std::string(jsonStr.data(), jsonStr.length()), nullptr, false);
 
@@ -160,6 +160,10 @@ namespace meen
 					return make_error_code(errc::json_parse);
 				}
 #endif // ENABLE_NLOHMANN_JSON
+			}
+			else
+			{
+				return make_error_code(errc::json_config);
 			}
 #ifdef ENABLE_NLOHMANN_JSON
 			if (json.contains("isrFreq") == true && json["isrFreq"].get<double>() < 0)

--- a/tests/source/meen_test/8080Test.cpp
+++ b/tests/source/meen_test/8080Test.cpp
@@ -1282,7 +1282,7 @@ TEST_F(MachineTest, CPI0)
 
 TEST_F(MachineTest, ISR_1)
 {
-	auto err = machine_->SetOptions(R"({"clockSamplingFreq":40})");
+	auto err = machine_->SetOptions(R"(json://{"clockSamplingFreq":40})");
 	EXPECT_FALSE(err);
 
 	// There is a chance for an infinite spin if the test fails.

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -198,7 +198,7 @@ namespace meen::Tests
 		// use the cpm io controller for cpm based tests
 		auto err = machine_->AttachIoController(std::move(cpmIoController_));
 		EXPECT_FALSE(err);
-		err = machine_->SetOptions(R"({"isrFreq":60})");
+		err = machine_->SetOptions(R"(json://{"isrFreq":60})");
 		EXPECT_FALSE(err);
 		//CP/M BDOS print message system call is at memory address 0x05,
 		//this will be emulated with the bdosMsg subroutine.
@@ -235,7 +235,7 @@ namespace meen::Tests
 		EXPECT_NO_THROW
 		(
 			//cppcheck-suppress unknownMacro
-			auto err = machine_->SetOptions(R"({"isrFreq":-1.0})");
+			auto err = machine_->SetOptions(R"(json://{"isrFreq":-1.0})");
 			EXPECT_EQ(errc::json_config, err.value());
 		);
 	}
@@ -252,7 +252,7 @@ namespace meen::Tests
 
 			// Set the resolution so the Run method takes about 1 second to complete therefore allowing subsequent IMachine method calls to return errors
 			//cppcheck-suppress unknownMacro
-			err = machine_->SetOptions(R"({"clockSamplingFreq":40,"runAsync":true, "isrFreq":60})"); // must be async so the Run method returns immediately
+			err = machine_->SetOptions(R"(json://{"clockSamplingFreq":40,"runAsync":true, "isrFreq":60})"); // must be async so the Run method returns immediately
 			EXPECT_FALSE(err);
 
 			// We aren't interested in saving, clear the onSave callback
@@ -263,7 +263,7 @@ namespace meen::Tests
 			EXPECT_FALSE(err);
 
 			// All these methods should return busy
-			err = machine_->SetOptions(R"({"isrFreq":1})");
+			err = machine_->SetOptions(R"(json://{"isrFreq":1})");
 			EXPECT_EQ(errc::busy, err.value());
 			err = machine_->AttachMemoryController(nullptr);
 			EXPECT_EQ(errc::busy, err.value());
@@ -286,7 +286,7 @@ namespace meen::Tests
 
 		if (runAsync == true)
 		{
-			err = machine_->SetOptions(R"({"runAsync":true})");
+			err = machine_->SetOptions(R"(json://{"runAsync":true})");
 			EXPECT_FALSE(err);
 		}
 
@@ -298,7 +298,7 @@ namespace meen::Tests
 
 		// Sample the host clock 40 times per second, giving a meen clock tick a resolution of 25 milliseconds
 		// Service interrupts 60 times per meen cpu clock rate. For an i8080 running at 2Mhz, this would service interrupts every 40000 ticks.
-		err = machine_->SetOptions(R"({"clockSamplingFreq":40,"isrFreq":60})");
+		err = machine_->SetOptions(R"(json://{"clockSamplingFreq":40,"isrFreq":60})");
 		EXPECT_FALSE(err);
 
 		err = machine_->Run();
@@ -387,7 +387,7 @@ namespace meen::Tests
 
 			if (runAsync == true)
 			{
-				err = machine_->SetOptions(R"({"runAsync":true,"loadAsync":false,"saveAsync":true})");
+				err = machine_->SetOptions(R"(json://{"runAsync":true,"loadAsync":false,"saveAsync":true})");
 				EXPECT_FALSE(err);
 			}
 

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -136,7 +136,7 @@ namespace meen::tests
 
         if (runAsync == true)
         {
-            err = machine->SetOptions(R"({"runAsync":true})");
+            err = machine->SetOptions(R"(json://{"runAsync":true})");
             TEST_ASSERT_FALSE(err);
         }
 
@@ -149,7 +149,7 @@ namespace meen::tests
 
    		// Sample the host clock 40 times per second, giving a meen clock tick a resolution of 25 milliseconds
 		// Service interrupts 60 times per meen cpu clock rate. For an i8080 running at 2Mhz, this would service interrupts every 40000 ticks.
-        err = machine->SetOptions(R"({"clockSamplingFreq":40, "isrFreq":60})");
+        err = machine->SetOptions(R"(json://{"clockSamplingFreq":40, "isrFreq":60})");
         TEST_ASSERT_FALSE(err);
 
         err = machine->Run();
@@ -259,7 +259,7 @@ namespace meen::tests
 
         if (runAsync == true)
         {
-            err = machine->SetOptions(R"({"runAsync":true,"loadAsync":false,"saveAsync":true})");
+            err = machine->SetOptions(R"(json://{"runAsync":true,"loadAsync":false,"saveAsync":true})");
 
             if(err.value() == errc::json_config)
             {
@@ -415,7 +415,7 @@ namespace meen::tests
     static void test_NegativeISRFrequency()
     {
         //cppcheck-suppress unknownMacro
-        auto err = machine->SetOptions(R"({"isrFreq":-1.0})");
+        auto err = machine->SetOptions(R"(json://{"isrFreq":-1.0})");
         TEST_ASSERT_TRUE(err);
     }
 
@@ -431,7 +431,7 @@ namespace meen::tests
 		// Sample the host clock 40 times per second, giving a meen clock tick a resolution of 25 milliseconds
 		// Service interrupts 60 times per meen cpu clock rate. For an i8080 running at 2Mhz, this would service interrupts every 40000 ticks.
         //cppcheck-suppress unknownMacro
-        err = machine->SetOptions(R"({"clockSampleFreq":40,"runAsync":true,"isrFreq":60})"); // must be async so the Run method returns immediately
+        err = machine->SetOptions(R"(json://{"clockSampleFreq":40,"runAsync":true,"isrFreq":60})"); // must be async so the Run method returns immediately
         TEST_ASSERT_FALSE(err);
 
         // We aren't interested in saving, clear the onSave callback
@@ -442,7 +442,7 @@ namespace meen::tests
         TEST_ASSERT_FALSE(err);
 
         // All these methods should return errc::busy
-        err = machine->SetOptions(R"({"isrFreq":1})");
+        err = machine->SetOptions(R"(json://{"isrFreq":1})");
         TEST_ASSERT_EQUAL_INT(static_cast<int>(errc::busy), err.value());
         err = machine->AttachMemoryController(nullptr);
         TEST_ASSERT_EQUAL_INT(static_cast<int>(errc::busy), err.value());
@@ -493,7 +493,7 @@ namespace meen::tests
         // use the cpm io controller for cpm based tests
         auto err = machine->AttachIoController(std::move(cpmIoController));
         TEST_ASSERT_FALSE(err);
-        err = machine->SetOptions(R"({"isrFreq":60})");
+        err = machine->SetOptions(R"(json://{"isrFreq":60})");
         TEST_ASSERT_FALSE(err);
         //CP/M BDOS print message system call is at memory address 0x05,
         //this will be emulated with the bdosMsg subroutine.

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -55,7 +55,7 @@ class MachineTest(unittest.TestCase):
         self.assertEqual(err, ErrorCode.NoError)
         # Using the default isrFreq setting of -1 (service interrupts at the end of each instruction) causes noticible performance issues, set it
         # to a number where on an i8080 running at 2Mhz, interrupts will be serviced every 40000 ticks.
-        err = self.machine.SetOptions(r'{"isrFreq":60}')
+        err = self.machine.SetOptions(r'json://{"isrFreq":60}')
         self.assertEqual(err, ErrorCode.NoError)
         # A base64 encoded code fragment that is loaded at address 0x0000 (for test suite compatibility) which saves the current machine state, powers off the machine, then halts the cpu.
         self.saveAndExit = 'base64://0/7T/3Y'
@@ -78,7 +78,7 @@ class MachineTest(unittest.TestCase):
         self.assertEqual(err, ErrorCode.InvalidArgument)
 
     def test_NegativeISRFrequency(self):
-        err = self.machine.SetOptions(r'{"isrFreq":-1.0}')
+        err = self.machine.SetOptions(r'json://{"isrFreq":-1.0}')
         self.assertEqual(err, ErrorCode.JsonConfig)
 
     def test_MethodsErrorAfterRunCalled(self):
@@ -90,7 +90,7 @@ class MachineTest(unittest.TestCase):
         self.assertEqual(err, ErrorCode.NoError)
 
 		#Sample the host clock 40 times per second, giving a meen clock tick a resolution of 25 milliseconds
-        err = self.machine.SetOptions(r'{"clockSamplingFreq":40,"runAsync":true}')
+        err = self.machine.SetOptions(r'json://{"clockSamplingFreq":40,"runAsync":true}')
         self.assertEqual(err, ErrorCode.NoError)
 
         # We aren't interested in saving, clear the onSave callback
@@ -100,7 +100,7 @@ class MachineTest(unittest.TestCase):
         err = self.machine.Run()
         self.assertEqual(err, ErrorCode.NoError)
 
-        err = self.machine.SetOptions(r'{"isrFreq":1}')
+        err = self.machine.SetOptions(r'json://{"isrFreq":1}')
         self.assertEqual(err, ErrorCode.Busy)
         err = self.machine.AttachMemoryController(self.memoryController)
         self.assertEqual(err, ErrorCode.Busy)
@@ -119,12 +119,12 @@ class MachineTest(unittest.TestCase):
         self.assertEqual(err, ErrorCode.NoError)
 
         if runAsync == True:
-            err = self.machine.SetOptions(r'{"runAsync":true}')
+            err = self.machine.SetOptions(r'json://{"runAsync":true}')
             self.assertEqual(err, ErrorCode.NoError)
 
         # Sample the host clock 40 times per second, giving a meen clock tick a resolution of 25 milliseconds
 		# Service interrupts 60 times per meen cpu clock rate. For an i8080 running at 2Mhz, this would service interrupts every 40000 ticks.
-        err = self.machine.SetOptions(r'{"clockSamplingFreq":40,"isrFreq":60}')
+        err = self.machine.SetOptions(r'json://{"clockSamplingFreq":40,"isrFreq":60}')
         self.assertEqual(err, ErrorCode.NoError)
 
         err = self.machine.Run()
@@ -185,11 +185,11 @@ class MachineTest(unittest.TestCase):
             self.skipTest("Machine.OnLoad is not supported")
 
         if runAsync == True:
-            err = self.machine.SetOptions(r'{"runAsync":true,"loadAsync":false,"saveAsync":true}')
+            err = self.machine.SetOptions(r'json://{"runAsync":true,"loadAsync":false,"saveAsync":true}')
             self.assertEqual(err, ErrorCode.NoError)
 
         # Need to set to 0 to catch all save interrupts
-        err = self.machine.SetOptions(r'{"isrFreq":0}')
+        err = self.machine.SetOptions(r'json://{"isrFreq":0}')
         self.assertEqual(err, ErrorCode.NoError)
 
         self.cpmIoController.Write(0xFD, 0, None)
@@ -239,7 +239,7 @@ class i8080Test(unittest.TestCase):
         self.machine.AttachMemoryController(self.memoryController)
         # Using the default isrFreq setting of -1 (service interrupts at the end of each instruction) causes noticible performance issues, set it
         # to a number where on an i8080 running at 2Mhz, interrupts will be serviced evey 40000 ticks.
-        err = self.machine.SetOptions(r'{"isrFreq":60}')
+        err = self.machine.SetOptions(r'json://{"isrFreq":60}')
         self.assertEqual(err, ErrorCode.NoError)
         self.saveTriggered = False
         # A base64 encoded code fragment that is loaded at address 0x0000 (for test suite compatibility) which saves the current machine state, powers off the machine, then halts the cpu.


### PR DESCRIPTION
- The protocol `json://` must be prefixed to the config string when using raw json to load configuration options.
- Updated the supported protocols table for the configuration options.
- Updated the unit tests my prepending `json://` to all SetOptions calls that use raw json.