### PR TITLE
#195 feat: OnLoad callback json uri schemes

### DIFF
--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -155,11 +155,11 @@ namespace meen::Tests
 		{
 			if (extra == nullptr)
 			{
-				return LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256}]}}})", saveAndExit, name);
+				return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256}]}}})", saveAndExit, name);
 			}
 			else
 			{
-				return LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256},{"bytes":"%s","offset":%d}]}}})", saveAndExit, name, extra, offset);
+				return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256},{"bytes":"%s","offset":%d}]}}})", saveAndExit, name, extra, offset);
 			}
 		});
 		EXPECT_FALSE(err);
@@ -246,7 +246,7 @@ namespace meen::Tests
 		(
 			auto err = machine_->OnLoad([progDir = programsDir_.c_str()](char* json, int* jsonLen)
 			{
-				return LoadProgram (json, jsonLen, R"({"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"%s","offset":50004}]}}})", saveAndExit, nopStart, nopEnd);
+				return LoadProgram (json, jsonLen, R"(json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"%s","offset":50004}]}}})", saveAndExit, nopStart, nopEnd);
 			});
 			EXPECT_FALSE(err);
 
@@ -292,7 +292,7 @@ namespace meen::Tests
 
 		err = machine_->OnLoad([progDir = programsDir_.c_str()](char* json, int* jsonLen)
 		{
-			return LoadProgram (json, jsonLen, R"({"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"%s","offset":50004}]}}})", saveAndExit, nopStart, nopEnd);
+			return LoadProgram (json, jsonLen, R"(json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"%s","offset":50004}]}}})", saveAndExit, nopStart, nopEnd);
 		});
 		EXPECT_FALSE(err);
 
@@ -363,11 +363,11 @@ namespace meen::Tests
 					// be subtracted from the total size of the file,
 					// hence an explicit setting of the test file size.
 					case 0:
-						err = LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"file://%s/TST8080.COM","offset":256,"size":1471}]}}})", saveAndExit, bdosMsg, progDir);
+						err = LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"file://%s/TST8080.COM","offset":256,"size":1471}]}}})", saveAndExit, bdosMsg, progDir);
 						break;
 					case 1:
 						// 0 - mid program save state, 1 and 2 - end of program save states
-						err = LoadProgram(json, jsonLen, saveStates[0].c_str());
+						err = LoadProgram(json, jsonLen, (std::string("json://") + saveStates[0]).c_str());
 						break;
 					default:
 						err = errc::invalid_argument;

--- a/tests/source/meen_test/MeenUnityTest.cpp
+++ b/tests/source/meen_test/MeenUnityTest.cpp
@@ -142,7 +142,7 @@ namespace meen::tests
 
         err = machine->OnLoad([progDir = programsDir.c_str()](char* json, int* jsonLen)
         {
-            return LoadProgram(json, jsonLen, R"({"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":50004,"size":%d}]}}})",
+            return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":50004,"size":%d}]}}})",
                                 saveAndExit.data(), saveAndExit.size(), nopStart.data(), nopStart.size(), nopEnd.data(), nopEnd.size());
         });
         TEST_ASSERT_FALSE(err);
@@ -225,7 +225,7 @@ namespace meen::tests
 #ifdef ENABLE_MEEN_RP2040
                 if (&tst8080End - &tst8080Start >= 1471)
                 {
-                    err = LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":256,"size":1471}]}}})",
+                    err = LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":256,"size":1471}]}}})",
                                        saveAndExit.data(), saveAndExit.size(), bdosMsg.data(), bdosMsg.size(), &tst8080Start);
                 }
                 else
@@ -233,13 +233,13 @@ namespace meen::tests
                     err = errc::incompatible_rom;
                 }
 #else
-                err = LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"file://%s/TST8080.COM","offset":256,"size":1471}]}}})",
+                err = LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"file://%s/TST8080.COM","offset":256,"size":1471}]}}})",
                                    saveAndExit.data(), saveAndExit.size(), bdosMsg.data(), bdosMsg.size(), progDir);
 #endif // ENABLE_MEEN_RP2040
                 break;
             case 1:
                 // 0 - mid program save state, 1 and 2 - end of program save states
-                err = LoadProgram(json, jsonLen, saveStates[0].c_str());
+                err = LoadProgram(json, jsonLen, (std::string("json://") + saveStates[0]).c_str());
                 break;
             default:
                 err = errc::invalid_argument;
@@ -387,7 +387,7 @@ namespace meen::tests
 
         err = machine->OnLoad([name, progSize](char* json, int* jsonLen)
         {
-            return LoadProgram(json, jsonLen, R"({"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"%s","offset":256,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d}]}}})",
+            return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"%s","offset":256,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d}]}}})",
                                 saveAndExit.data(), saveAndExit.size(), name, progSize, bdosMsg.data(), bdosMsg.size());
         });
         TEST_ASSERT_FALSE(err);
@@ -423,7 +423,7 @@ namespace meen::tests
     {
         auto err = machine->OnLoad([progDir = programsDir.c_str()](char* json, int* jsonLen)
         {
-            return LoadProgram(json, jsonLen, R"({"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":50004,"size":%d}]}}})",
+            return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"mem://%p","offset":0,"size":%d},{"bytes":"mem://%p","offset":5,"size":%d},{"bytes":"mem://%p","offset":50004,"size":%d}]}}})",
                                 saveAndExit.data(), saveAndExit.size(), nopStart.data(), nopStart.size(), nopEnd.data(), nopEnd.size());
         });
         TEST_ASSERT_FALSE(err);

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -85,7 +85,7 @@ class MachineTest(unittest.TestCase):
         # Write to the 'load device', the value doesn't matter (use 0)
         self.testIoController.Write(0xFD, 0, None)
 
-        err = self.machine.OnLoad(lambda: r'{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.nopStart + r'","offset":5},{"bytes":"' + self.nopEnd + r'","offset":50004}]}}}')
+        err = self.machine.OnLoad(lambda: r'json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.nopStart + r'","offset":5},{"bytes":"' + self.nopEnd + r'","offset":50004}]}}}')
 
         self.assertEqual(err, ErrorCode.NoError)
 
@@ -115,7 +115,7 @@ class MachineTest(unittest.TestCase):
         # Write to the 'load device', the value doesn't matter (use 0)
         self.testIoController.Write(0xFD, 0, None)
 
-        err = self.machine.OnLoad(lambda: r'{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.nopStart + r'","offset":5},{"bytes":"' + self.nopEnd + r'","offset":50004}]}}}')
+        err = self.machine.OnLoad(lambda: r'json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.nopStart + r'","offset":5},{"bytes":"' + self.nopEnd + r'","offset":50004}]}}}')
         self.assertEqual(err, ErrorCode.NoError)
 
         if runAsync == True:
@@ -170,9 +170,9 @@ class MachineTest(unittest.TestCase):
 
             match self.loadIndex:
                 case 0:
-                    jsonToLoad = r'{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.bdosMsg + r'","offset":5},{"bytes":"file://' + self.programsDir + r'/TST8080.COM","offset":256,"size":1471}]}}}'
+                    jsonToLoad = r'json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.bdosMsg + r'","offset":5},{"bytes":"file://' + self.programsDir + r'/TST8080.COM","offset":256,"size":1471}]}}}'
                 case 1:
-                    jsonToLoad = saveStates[0]
+                    jsonToLoad = 'json://' + saveStates[0]
                 case _:
                     pass
 
@@ -269,7 +269,7 @@ class i8080Test(unittest.TestCase):
     def RunTestSuite(self, suiteName, expectedState, expectedMsg):
         # Write to the 'load device', the value doesn't matter (use 0)
         self.cpmIoController.Write(0xFD, 0, None)
-        err = self.machine.OnLoad(lambda: r'{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.bdosMsg + r'","offset":5},{"bytes":"file://' + self.programsDir + '/' + suiteName + r'","offset":256}]}}}')
+        err = self.machine.OnLoad(lambda: r'json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"' + self.saveAndExit + r'","offset":0},{"bytes":"' + self.bdosMsg + r'","offset":5},{"bytes":"file://' + self.programsDir + '/' + suiteName + r'","offset":256}]}}}')
         self.assertEqual(err, ErrorCode.NoError)
         err = self.machine.OnSave(lambda actualState: self.CheckMachineState(expectedState, actualState))
         self.assertIn(err, [ErrorCode.NoError, ErrorCode.NotImplemented])


### PR DESCRIPTION
Added support for state loading via the following schemes:
- `file://`: the raw json to load is to be read from the local file specified by the remaining string.
- `json://`: the raw json to load resides in the remaining string.

When no recognised scheme is found at the start of the load string a json config error message is echoed (proper logging and error handling will be the subject of a future pull request).  