### PR TITLE
#228 fix: improve the `onLoad` handler

### DIFF
--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -43,7 +43,7 @@ namespace meen
 	{
 		i8080
 	};
-	
+
 	/** Machine
 
 		@see IMachine.h
@@ -69,7 +69,7 @@ namespace meen
 		std::map<uint16_t, uint16_t> ramMetadata_;
 		//cppcheck-suppress unusedStructMember
 		bool running_{};
-		std::function<bool(IController* ioController)>&& onIdle_{};
+		std::function<bool(IController* ioController)> onIdle_{};
 		std::function<errc(char* json, int* jsonLen, IController* ioController)> onLoad_{};
 #ifdef ENABLE_MEEN_SAVE
 		std::function<errc(const char* json, IController* ioController)> onSave_{};
@@ -90,7 +90,7 @@ namespace meen
 			@see IMachine::AttachMemoryController
 		*/
 		std::error_code AttachMemoryController (IControllerPtr&& controller) final;
-		
+
 		/** DetachMemoryController
 
 			@see IMachine::DetachMemoryController
@@ -128,7 +128,7 @@ namespace meen
 		std::error_code OnSave(std::function<errc(const char* json, IController* ioController)>&& onSave) final;
 
 		/** OnIdle
-		
+
 			@see IMachine::OnIdle
 		*/
 		std::error_code OnIdle(std::function<bool(IController* ioController)>&& onIdle) final;

--- a/include/meen/machine/Machine.h
+++ b/include/meen/machine/Machine.h
@@ -70,9 +70,9 @@ namespace meen
 		//cppcheck-suppress unusedStructMember
 		bool running_{};
 		std::function<bool(IController* ioController)>&& onIdle_{};
-		std::function<std::error_code(char* json, int* jsonLen, IController* ioController)> onLoad_{};
+		std::function<errc(char* json, int* jsonLen, IController* ioController)> onLoad_{};
 #ifdef ENABLE_MEEN_SAVE
-		std::function<std::error_code(const char* json, IController* ioController)> onSave_{};
+		std::function<errc(const char* json, IController* ioController)> onSave_{};
 #endif // ENABLE_MEEN_SAVE
 		friend void RunMachine(Machine* machine);
 	public:

--- a/include/meen/opt/Opt.h
+++ b/include/meen/opt/Opt.h
@@ -135,6 +135,12 @@ namespace meen
 			*/
 			bool SaveAsync() const;
 #endif
+			/**	The maximum length of the json machine state asset
+
+				This is the length of the buffer passed to the OnLoad
+				registration handler.
+			*/
+			int MaxLoadStateLength() const;
 	};
 } // namespace meen
 

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -814,7 +814,7 @@ namespace meen
 							{
 								str.clear();
 								// todo: need to have proper logging
-								printf("ISR::Load failed to load the machine state: %s\n", e.message().c_str());
+								printf("ISR::Load failed to load the machine state: %s\n", make_error_code(e).message().c_str());
 							}
 #ifndef ENABLE_MEEN_RP2040
 							return str;
@@ -906,8 +906,12 @@ namespace meen
 										onSave = std::async(saveLaunchPolicy, [onSave_, state = writeState(), ioController]
 										{
 											// TODO: this method needs to be marked as nothrow
-											onSave_(state.c_str(), ioController);
-											// handle return error_code
+											auto e = onSave_(state.c_str(), ioController);
+											
+											if (e)
+											{
+												printf("ISR::Save failed to save the machine state: %s\n", make_error_code(e).message().c_str());
+											}
 
 											return std::string("");
 										});

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -796,19 +796,13 @@ namespace meen
 					)
 					{
 #ifndef ENABLE_MEEN_RP2040
-						onLoad = std::async(loadLaunchPolicy, [onLoad_, ioController]
+						onLoad = std::async(loadLaunchPolicy, [onLoad_, ioController, loadSize = opt_.MaxLoadStateLength()]
 						{
 #endif // ENABLE_MEEN_RP2040
-							std::string str;
-							int len = 0;
-							auto e = onLoad_(nullptr, &len, ioController);
+							int len = loadSize;
+							std::string str(len, '\0');
 
-							if(!e)
-							{
-								len++;
-								str.resize(len, '\0');
-								e = onLoad_(str.data(), &len, ioController);
-							}
+							auto e = onLoad_(str.data(), &len, ioController);
 
 							if(e)
 							{
@@ -816,6 +810,8 @@ namespace meen
 								// todo: need to have proper logging
 								printf("ISR::Load failed to load the machine state: %s\n", make_error_code(e).message().c_str());
 							}
+
+							str.resize(len);
 #ifndef ENABLE_MEEN_RP2040
 							return str;
 						});

--- a/source/machine_py/MachineModule.cpp
+++ b/source/machine_py/MachineModule.cpp
@@ -76,29 +76,15 @@ PYBIND11_MODULE(meenPy, meen)
         {
             return static_cast<meen::errc>(machine.OnLoad([ol = std::move(onLoad)](char* json, int* jsonLen, meen::IController* ioController)
             {
-                // This static needs to be addressed ..... we could use a wrapper class for meen to store this ... don't really want to. :(
-                static std::string jsonToLoad_;
+                auto loadState = ol(ioController);
 
-                if(jsonLen == nullptr)
+                if (loadState.size() > *jsonLen)
                 {
                     return meen::errc::invalid_argument;
                 }
 
-                if (json == nullptr)
-                {
-                    jsonToLoad_ = ol(ioController);
-                    *jsonLen = jsonToLoad_.length();
-                }
-                else
-                {
-                    if (jsonToLoad_.length() != *jsonLen - 1)
-                    {
-                        return meen::errc::invalid_argument;
-                    }
-
-                    strncpy(json, jsonToLoad_.c_str(), *jsonLen);
-                }
-                
+                *jsonLen = loadState.length();
+                strncpy(json, loadState.c_str(), *jsonLen);
                 return meen::errc::no_error;
             }).value());            
         })

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -80,7 +80,7 @@ namespace meen
 #else
 								R"(")"
 #endif // ENABLE_MEEN_SAVE
-								R"(,"isrFreq":0,"runAsync":false})"sv;
+								R"(,"isrFreq":0,"maxLoadStateLen":512,"runAsync":false})"sv;
 	}
 
 #ifdef ENABLE_NLOHMANN_JSON
@@ -267,4 +267,13 @@ namespace meen
 #endif // ENABLE_NLOHMANN_JSON
 	}
 #endif // ENABLE_MEEN_SAVE
+
+	int Opt::MaxLoadStateLength() const
+	{
+#ifdef ENABLE_NLOHMANN_JSON
+	return json_["maxLoadStateLen"].get<int>();
+#else
+	return json_["maxLoadStateLen"].as<int>();
+#endif // ENABLE_NLOHMANN_JSON
+	}
 } // namespace meen

--- a/source/utils/ErrorCode.cpp
+++ b/source/utils/ErrorCode.cpp
@@ -42,6 +42,8 @@ namespace meen
 				{
 					case errc::no_error:
 						return "Success";
+					case errc::async:
+						return "An asynchronous operation failed to complete";
 					case errc::busy:
 						return "The engine is running";
 					case errc::clock_sampling_freq:

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -118,15 +118,18 @@ namespace meen::Tests
 		va_list args;
 		va_start(args, fmt);
 
-		if (json == nullptr)
+		auto len = vsnprintf(json, *jsonLen, fmt, args);
+		
+		// A write error occurred while executing the function, odds are that one of our parameters are incorrect.
+		// When len == *jsonLen, the config option `maxLoadStateLen` needs to be increased
+		if (len < 0 || len == *jsonLen)
 		{
-			*jsonLen = vsnprintf(nullptr, 0, fmt, args);
-			return *jsonLen == -1 ? errc::invalid_argument : errc::no_error;
+			return errc::invalid_argument;
 		}
-		else
-		{
-			return vsnprintf(json, *jsonLen, fmt, args) != *jsonLen - 1 ? errc::invalid_argument : errc::no_error;
-		}
+
+		// Write the final length of the loaded program
+		*jsonLen = len;
+		return errc::no_error;
 	}
 
 	void MachineTest::LoadAndRun(const char* name, const char* expected, const char* extra, uint16_t offset)


### PR DESCRIPTION
Changed the behaviour of the `OnLoad` handler to be simpler.

- Added the configuration option `maxLoadStateLen` to specify to maximum length of the `IMachine::OnLoad` handler `json` c string parameter.
- The on load handler should return errc::invalid_argument when the value of `jsonLen` pointer is too small.
- Upon successfully writing the state to the `json` c string parameter the `jsonLen` parameter should be set to the correct length.
- Fixed some minor issues relating to the onLoad/Save handlers. 